### PR TITLE
chore: update image to use go-toolset & add sha

### DIFF
--- a/redhat/patches/0001-dockerfile.patch
+++ b/redhat/patches/0001-dockerfile.patch
@@ -1,13 +1,12 @@
 diff --git a/Dockerfile b/Dockerfile
-index b97a905..dbb6575 100644
+index dbb6575..63c023e 100644
 --- a/Dockerfile
 +++ b/Dockerfile
 @@ -13,7 +13,7 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 
--FROM golang:1.20.6@sha256:cfc9d1b07b1ef4f7a4571f0b60a99646a92ef76adb7d9943f4cb7b606c6554e2 AS builder
-+FROM registry.access.redhat.com/ubi9/ubi-micro AS builder
+-FROM registry.access.redhat.com/ubi9/ubi-micro AS builder
++FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS builder
  ENV APP_ROOT=/opt/app-root
  ENV GOPATH=$APP_ROOT
-


### PR DESCRIPTION
The `docker build` of this repository will not work with the base UBI image. We need to use the `go-toolset` image instead.