### PR TITLE
chore: add OWNERS file for OpenShift CI / Prow

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,12 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- lance
+- cooktheryan
+- lkatalin
+- sallom
+
+reviewers:
+- JasonPowr
+- tommyd450
+


### PR DESCRIPTION
Needed by the OpenShift prow jobs. This enables actions through commands such as /lgtm and /approve.