### PR TITLE
chore: add OWNERS to release-next branch

### DIFF
--- a/redhat/release/update-to-head.sh
+++ b/redhat/release/update-to-head.sh
@@ -27,6 +27,7 @@ REPO_NAME=$(basename $(git rev-parse --show-toplevel))
 # Custom files
 custom_files=$(cat <<EOT | tr '\n' ' '
 redhat
+OWNERS
 EOT
 )
 redhat_files_msg=":open_file_folder: update Red Hat specific files"


### PR DESCRIPTION
This is needed on the repo for OpenShift CI to allow merging. It exists in the `main` branch, but should be copied to the `release-next` branch in order to handle merges from prow.