### PR TITLE
chore: modify sync script to update based on git-ref

### DIFF
--- a/redhat/patches/0001-dockerfile.patch
+++ b/redhat/patches/0001-dockerfile.patch
@@ -5,18 +5,18 @@ index 39c728e..16989b1 100644
 @@ -13,7 +13,7 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
- 
+
 -FROM golang:1.20.7@sha256:bc5f0b5e43282627279fe5262ae275fecb3d2eae3b33977a7fd200c7a760d6f1 AS builder
 +FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS builder
  ENV APP_ROOT=/opt/app-root
  ENV GOPATH=$APP_ROOT
- 
+
 @@ -31,7 +31,7 @@ RUN CGO_ENABLED=0 go build -gcflags "all=-N -l" -ldflags "${SERVER_LDFLAGS}" -o
  RUN go test -c -ldflags "${SERVER_LDFLAGS}" -cover -covermode=count -coverpkg=./... -o rekor-server_test ./cmd/rekor-server
- 
+
  # Multi-Stage production build
 -FROM golang:1.20.7@sha256:bc5f0b5e43282627279fe5262ae275fecb3d2eae3b33977a7fd200c7a760d6f1 as deploy
 +FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as deploy
- 
+
  # Retrieve the binary from the previous stage
  COPY --from=builder /opt/app-root/src/rekor-server /usr/local/bin/rekor-server


### PR DESCRIPTION
If provided the update-to-head.sh script will now accept an upstream git-ref (typically a release tag, e.g. 1.2.2). If a git-ref is provided, there MUST be a corresponding branch in securesign/rekor with the same name, prefixed with "midstream-", e.g. "midstream-v1.2.2". The script also pushes to a `redhat-<git-ref>` branch if a git-ref was provided.

This allows us to maintain branch history in midstream, corresponding to upstream releases, and typically pins the upstream Dockerfile sha.

I have also recently pushed a [`midstream-v1.2.2`](https://github.com/securesign/rekor/tree/midstream-v1.2.2) branch to test this against once this PR lands. As [you can see](https://github.com/securesign/rekor/compare/main...securesign:rekor:midstream-v1.2.2) the branch maintains the specific updates required for modifying the upstream at `<git-ref>`.

Once this is all working smoothly, the image-factory repo should be updated to point to specific `redhat-<git-ref>` branches on this repo.

This commit also includes the latest upstream changes to the Dockerfile sha.
