### PR TITLE
chore: better handling of versioned branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,27 +5,52 @@ This repository holds the Red Hat fork of
 
 ## Mirroring upstream
 
-The upstream repo, `sigstore/rekor` is mirrored on the
-`release-next` and `release-next-ci` branches, as well as all of the existing
-release branches.
+### Mirroring HEAD from upstream `main`
 
-In order for mirroring to work correctly, you'll need to have two git remotes
-for this repository.
+The HEAD of the upstream repo, `sigstore/rekor` is mirrored on the
+`release-next` and `release-next-ci` branches using the [`redhat/release/update-to-head.sh`](redhat/release/update-to-head.sh) script. When this script is run without any arguments, the following steps are taken.
 
-- `upstream` pointing to `sigstream/rekor`
-- `origin` pointing to `securesign/rekor` (this repo)
-
-When we are preparing to release a new version of Red Hat SecureSign Rekor,
-we need to mirror the upstream repository and apply the patches and origin.
-This is done using the `origin/release/update-to-head.sh` script. When it runs,
-the following steps are taken.
-
-- The upstream is fetched and checked out as the `release-next` branch
-- The `origin` remote `main` branch is pulled and Red Hat specific files from that branch are applied to the `release-next` branch
+- The upstream HEAD is fetched and checked out as the `release-next` branch
+- The `origin` remote `main` branch is pulled and Red-Hat-specific files from that branch are applied to the `release-next` branch
 - The `release-next` branch is force pushed to the `origin` remote
 - The `release-next` branch is duplicated to `release-next-ci`
 - A timestamp file is added to `release-next-ci` branch
 - The `release-next-ci` branch is force pushed to the `origin` remote
 - A pull request is created (if it does not already exist) for this change, to trigger a CI run
+- OpenShift CI runs the upstream unit and integration tests on the PR
 
-TODO: Actually set up CI to run on the `release-next-ci` branch when a change is pushed to it.
+### Mirroring releases from upstream release branches
+
+Branches for specific versions may also be managed using this script by supplying a `git-ref` when running the script.
+
+```
+./redhat/release/update-to-head.sh v1.2.2
+```
+
+To mirror a release branch from upstream, a branch for our midstream changes must exist. The naming for this branch is in the form `midstream-vX.Y.Z` where `vX.Y.Z` corresponds to an upstream release branch. For example, to mirror, modify and test the upstream version `v1.2.2` from your local laptop, you would take the following steps.
+
+1. Ensure the patch file from `main` and any other modifications we make in midstream cleanly applies on the upstream release branch. If it doesn't fix that first.
+2. Push a new branch based on our midstream `main` - e.g. `git push origin main:midstream-v1.2.2`
+3. Run `./redhat/release/update-to-head.sh v1.2.2`, providing `v1.2.2` as the upstream branch to mirror.
+
+This will create a new "release" branch of the form `redhat-vX.Y.Z`, in this case `redhat-v1.2.2` and a corresponding CI branch for testing, `redhat-v1.2.2-ci`. Then a PR is opened to apply these changes to the midstream release branch, `redhat-v1.2.2`. If OpenShift CI has been configured for this new branch, it will run the unit and integration tests from upstream on the PR.
+
+## Local configuration
+
+To use this script locally, you'll need to have two git remotes for this repository.
+
+- `upstream` pointing to `sigstream/rekor`
+- `origin` pointing to `securesign/rekor` (this repo)
+
+### Example to mirror the upstream v1.2.2 release and kick off CI
+```
+git clone git@github.com:securesign/rekor.git
+cd rekor
+# Ensure that the patches cleanly apply
+git push origin main:midstream-v1.2.2
+# Add upstream as a remote
+git remote add upstream git@github.com/sigstore/rekor.git
+# Run the update script
+./redhat/release/update-to-head.sh v1.2.2
+```
+This should create the `redhat-v1.2.2` branch as well as a test branch at `redhat-v1.2.2-ci`, create a pull request, and initiate OpenShift CI.

--- a/redhat/release/update-to-head.sh
+++ b/redhat/release/update-to-head.sh
@@ -29,13 +29,14 @@
 if [ "$#" -ne 1 ]; then
     upstream_ref="main"
     midstream_ref="main"
+    redhat_ref="release-next"
 else
     upstream_ref=$1
-    midstream_ref="midstream-${upstream_ref}"
-    redhat_ref="redhat-${upstream_ref}"
+    midstream_ref="midstream-${upstream_ref}" # The overlays and patches for the given version
+    redhat_ref="redhat-${upstream_ref}" # The midstream repo with overlays and patches applied
 fi
 
-echo "Synchronizing release-next to upstream/${upstream_ref}..."
+echo "Synchronizing ${redhat_ref} to upstream/${upstream_ref}..."
 
 set -e
 REPO_NAME=$(basename $(git rev-parse --show-toplevel))
@@ -47,14 +48,14 @@ OWNERS
 EOT
 )
 redhat_files_msg=":open_file_folder: update Red Hat specific files"
-robot_trigger_msg=":robot: triggering CI on branch 'release-next' after synching from upstream/${upstream_ref}"
+robot_trigger_msg=":robot: triggering CI on branch '${redhat_ref}' after synching from upstream/${upstream_ref}"
 
 # Reset release-next to upstream main or <git-ref>.
 git fetch upstream $upstream_ref
 if [[ "$upstream_ref" == "main" ]]; then
-  git checkout upstream/main -B release-next
+  git checkout upstream/main -B ${redhat_ref}
 else
-  git checkout $upstream_ref -B release-next
+  git checkout $upstream_ref -B ${redhat_ref}
 fi
 
 # Update redhat's main and take all needed files from there.
@@ -71,27 +72,22 @@ git add $custom_files # Adds custom files
 git commit -m "${redhat_files_msg}"
 
 # Push the release-next branch
-git push -f origin release-next
-
-# Copy and push the release-next branch to $redhat_ref we're not working with main
-if [[ "$redhat_ref" != "" ]]; then
-  git push -f origin release-next:$redhat_ref
-fi
+git push -f origin "${redhat_ref}"
 
 # Trigger CI
 # TODO: Set up openshift or github CI to run on release-next-ci
-git checkout release-next -B release-next-ci
+git checkout "${redhat_ref}" -B "${redhat_ref}"-ci
 date > ci
 git add ci
 git commit -m "${robot_trigger_msg}"
-git push -f origin release-next-ci
+git push -f origin "${redhat_ref}-ci"
 
 if hash hub 2>/dev/null; then
    # Test if there is already a sync PR in
    COUNT=$(hub api -H "Accept: application/vnd.github.v3+json" repos/securesign/${REPO_NAME}/pulls --flat \
     | grep -c "${robot_trigger_msg}") || true
    if [ "$COUNT" = "0" ]; then
-      hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b securesign/${REPO_NAME}:release-next -h securesign/${REPO_NAME}:release-next-ci -m "${robot_trigger_msg}"
+      hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b securesign/${REPO_NAME}:${redhat_ref} -h securesign/${REPO_NAME}:${redhat_ref}-ci -m "${robot_trigger_msg}"
    fi
 else
    echo "hub (https://github.com/github/hub) is not installed, so you'll need to create a PR manually."


### PR DESCRIPTION
In https://github.com/securesign/rekor/commit/b5f82dfbf11a19e4526c414d169beb45deb92790 there were some improvements to how we can handle versions in CI. However, I don't think those changes were really enough. In that commit, I conflated the `release-next` branch with "whatever we happened to be building". But really I think it's better to use separate branches all around.

With this commit, the update script now does the following.

- If no arguments are supplied, it uses the `release-next` and `release-next-ci` branches to synchronize the absolute latest from upstream to our `release-next` branch. This is exactly what we started with.
- If a git-ref is supplied, it creates or force pushes a `redhat-${git-ref}` branch which is our midstream version of upstream at `${git-ref}` (patches applied, etc). Then creates or force pushes to a `redhat-${git-ref}-ci` branch to trigger openshift CI. This will require an openshift CI configuration for each release branch we want to track - I'm working on that too.

Note that, as before, for this whole flow to work there also needs to be a `midstream-${git-ref}` branch that looks like our `main` (empty except for overlays/patches/etc) which contains the patches that work with that specific upstream `${git-ref}`.

@sallyom since you reviewed the original changes, can you ptal? Thanks!