### PR TITLE
add dockerfile for rekor-cli

### DIFF
--- a/redhat/overlays/rekor-cli/Dockerfile.cli
+++ b/redhat/overlays/rekor-cli/Dockerfile.cli
@@ -1,0 +1,14 @@
+#Build stage
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
+USER root
+RUN git config --global --add safe.directory /opt/app-root/src
+COPY . .
+RUN make rekor-cli
+
+#Install stage
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6
+COPY --from=build-env /opt/app-root/src/rekor-cli /usr/local/bin/rekor-cli
+WORKDIR /opt/app-root/src/home
+
+#ENTRYPOINT
+ENTRYPOINT [ "rekor-cli" ]


### PR DESCRIPTION
This pr is related to this issue [here](https://github.com/securesign/rekor/issues/14), it involves creating a dockerfile for the rekor-cli binary.

## Testing
1.  Place the Dockerfile in the root directory of https://github.com/securesign/rekor/tree/release-next, or https://github.com/securesign/rekor/tree/redhat-v1.2.2
2. Build the dockerfile using this cmd `podman build . -t quay.io/<repo_name>/rekor-cli:v1.2.2 -f Dockerfile.cli`
3. Once built you should be able to access the rekor cli like so `podman run quay.io/<repo_name>/rekor-cli:v1.2.2 <rekor-cli-command>`