### PR TITLE
chore: modify update script to not send auth

### DIFF
--- a/.github/workflows/cronjobs.yaml
+++ b/.github/workflows/cronjobs.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Configure upstream
-        run: git remote add upstream git@github.com:sigstore/rekor.git
+        run: git remote add upstream https://github.com/sigstore/rekor
       - name: Check for existing pull request
         run: |
           openPRs="$(gh pr list --state open -H release-next-ci --json number | jq -r '.[].number' | wc -l)"


### PR DESCRIPTION
The github workflow that runs this script to update HEAD was using a git URL for the remote. That was causing failures in the action since there's no auth from there. Just using HTTP should resolve the issue.