### PR TITLE
chore: update tekton pipelines with correct naming

### DIFF
--- a/.tekton/rekor-server-pull-request.yaml
+++ b/.tekton/rekor-server-pull-request.yaml
@@ -12,9 +12,9 @@ metadata:
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rekor
-    appstudio.openshift.io/component: rekor-cli
+    appstudio.openshift.io/component: rekor-server
     pipelines.appstudio.openshift.io/type: build
-  name: rekor-cli-on-pull-request
+  name: rekor-server-on-pull-request
   namespace: securesign-tenant
 spec:
   params:
@@ -25,7 +25,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/securesign-tenant/rekor/rekor-cli:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/securesign-tenant/rekor/rekor-server:on-pr-{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/rekor-server-push.yaml
+++ b/.tekton/rekor-server-push.yaml
@@ -11,9 +11,9 @@ metadata:
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: rekor
-    appstudio.openshift.io/component: rekor-cli
+    appstudio.openshift.io/component: rekor-server
     pipelines.appstudio.openshift.io/type: build
-  name: rekor-cli-on-push
+  name: rekor-server-on-push
   namespace: securesign-tenant
 spec:
   params:
@@ -22,7 +22,7 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/securesign-tenant/rekor/rekor-cli:{{revision}}
+    value: quay.io/redhat-user-workloads/securesign-tenant/rekor/rekor-server:{{revision}}
   - name: path-context
     value: .
   - name: revision


### PR DESCRIPTION
I think my wires got crossed when I first attempted to onboard multiple components in a single repo. The name of the pipelines was mixed up with the name of the files. Anyhooo... I believe this should fix it.