### PR TITLE
feat: add Dockerfile for backfill-redis

### DIFF
--- a/redhat/overlays/Dockerfile.backfill-redis
+++ b/redhat/overlays/Dockerfile.backfill-redis
@@ -1,0 +1,14 @@
+#Build stage
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
+USER root
+RUN git config --global --add safe.directory /opt/app-root/src
+COPY . .
+RUN make backfill-redis
+
+#Install stage
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6
+COPY --from=build-env /opt/app-root/src/backfill-redis /usr/local/bin/backfill-redis
+WORKDIR /opt/app-root/src/home
+
+#ENTRYPOINT
+ENTRYPOINT [ "backfill-redis" ]

--- a/redhat/patches/0002-makefile.patch
+++ b/redhat/patches/0002-makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 9c2467b..4904ad9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -83,7 +83,7 @@ rekor-server: $(SRCS)
+ 	CGO_ENABLED=0 go build -trimpath -ldflags "$(SERVER_LDFLAGS)" -o rekor-server ./cmd/rekor-server
+
+ backfill-redis: $(SRCS)
+-	CGO_ENABLED=0 go build -trimpath -ldflags "$(SERVER_LDFLAGS)" -o rekor-server ./cmd/backfill-redis
++	CGO_ENABLED=0 go build -trimpath -ldflags "$(SERVER_LDFLAGS)" -o backfill-redis ./cmd/backfill-redis
+
+ test:
+ 	go test ./...


### PR DESCRIPTION
This commit adds a Dockerfile for building a `backfill-redis` image, which should be used periodically to ensure that redis contains the complete rekor log.

The patchfile is required due to this upstream issue:

https://github.com/sigstore/rekor/pull/1685

Once that pull request has been merged, we'll need to remove the patchfile from `main` but not from the `midstream-v1.2.2` branch unless it is backported upstream.

/cherry-pick midstream-v1.2.2
