### PR TITLE
add-unit-testing-to-rhtap

### DIFF
--- a/.tekton/backfill-redis-pull-request.yaml
+++ b/.tekton/backfill-redis-pull-request.yaml
@@ -365,6 +365,20 @@ spec:
         operator: in
         values:
         - "false"
+    - name: unit-test
+      runAfter:
+      - clone-repository
+      workspaces:
+        - name: output
+          workspace: workspace
+      taskSpec:
+        steps:
+        - name: run-unit-tests
+          image: registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6
+          script: |
+            #!/bin/bash
+            cd / && cd workspace/output
+            GOFLAGS="" make test
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/backfill-redis-push.yaml
+++ b/.tekton/backfill-redis-push.yaml
@@ -362,6 +362,20 @@ spec:
         operator: in
         values:
         - "false"
+    - name: unit-test
+      runAfter:
+      - clone-repository
+      workspaces:
+        - name: output
+          workspace: workspace
+      taskSpec:
+        steps:
+        - name: run-unit-tests
+          image: registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6
+          script: |
+            #!/bin/bash
+            cd / && cd workspace/output
+            GOFLAGS="" make test
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/rekor-cli-pull-request.yaml
+++ b/.tekton/rekor-cli-pull-request.yaml
@@ -365,6 +365,20 @@ spec:
         operator: in
         values:
         - "false"
+    - name: unit-test
+      runAfter:
+      - clone-repository
+      workspaces:
+        - name: output
+          workspace: workspace
+      taskSpec:
+        steps:
+        - name: run-unit-tests
+          image: registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6
+          script: |
+            #!/bin/bash
+            cd / && cd workspace/output
+            GOFLAGS="" make test
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/rekor-cli-push.yaml
+++ b/.tekton/rekor-cli-push.yaml
@@ -362,6 +362,20 @@ spec:
         operator: in
         values:
         - "false"
+    - name: unit-test
+      runAfter:
+      - clone-repository
+      workspaces:
+        - name: output
+          workspace: workspace
+      taskSpec:
+        steps:
+        - name: run-unit-tests
+          image: registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6
+          script: |
+            #!/bin/bash
+            cd / && cd workspace/output
+            GOFLAGS="" make test
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/rekor-server-pull-request.yaml
+++ b/.tekton/rekor-server-pull-request.yaml
@@ -365,6 +365,20 @@ spec:
         operator: in
         values:
         - "false"
+    - name: unit-test
+      runAfter:
+      - clone-repository
+      workspaces:
+        - name: output
+          workspace: workspace
+      taskSpec:
+        steps:
+        - name: run-unit-tests
+          image: registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6
+          script: |
+            #!/bin/bash
+            cd / && cd workspace/output
+            GOFLAGS="" make test
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/rekor-server-push.yaml
+++ b/.tekton/rekor-server-push.yaml
@@ -362,6 +362,20 @@ spec:
         operator: in
         values:
         - "false"
+    - name: unit-test
+      runAfter:
+      - clone-repository
+      workspaces:
+        - name: output
+          workspace: workspace
+      taskSpec:
+        steps:
+        - name: run-unit-tests
+          image: registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6
+          script: |
+            #!/bin/bash
+            cd / && cd workspace/output
+            GOFLAGS="" make test
     workspaces:
     - name: workspace
     - name: git-auth


### PR DESCRIPTION
This pr adds unit testing to rhtap for rekor. I've created my own version of rekor in rhtap in my own workspace and have tested both fail and success scenarios for both.

## Comments
I only went with that image as its the same used in the Docker files, if it needs to be changed let me know :+1: 
Gonna work on the e2e tests next