### PR TITLE
update patch file

### DIFF
--- a/redhat/overlays/Dockerfile.backfill-redis
+++ b/redhat/overlays/Dockerfile.backfill-redis
@@ -1,12 +1,12 @@
 #Build stage
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:e91cbbd0b659498d029dd43e050c8a009c403146bfba22cbebca8bcd0ee7925f AS build-env
 USER root
 RUN git config --global --add safe.directory /opt/app-root/src
 COPY . .
 RUN make backfill-redis
 
 #Install stage
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:e91cbbd0b659498d029dd43e050c8a009c403146bfba22cbebca8bcd0ee7925f
 
 LABEL description="Backfillredis is a job that will go through the TLog and make sure that missing entries are added to the search index."
 LABEL io.k8s.description="Backfillredis is a job that will go through the TLog and make sure that missing entries are added to the search index."

--- a/redhat/overlays/Dockerfile.cli
+++ b/redhat/overlays/Dockerfile.cli
@@ -1,12 +1,12 @@
 #Build stage
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS build-env
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:e91cbbd0b659498d029dd43e050c8a009c403146bfba22cbebca8bcd0ee7925f AS build-env
 USER root
 RUN git config --global --add safe.directory /opt/app-root/src
 COPY . .
 RUN make rekor-cli
 
 #Install stage
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:e91cbbd0b659498d029dd43e050c8a009c403146bfba22cbebca8bcd0ee7925f
 
 LABEL description="Rekor-cli is a command line interface (CLI) tool used to interact with a rekor server."
 LABEL io.k8s.description="Rekor-cli is a command line interface (CLI) tool used to interact with a rekor server."

--- a/redhat/patches/0001-dockerfile.patch
+++ b/redhat/patches/0001-dockerfile.patch
@@ -1,5 +1,5 @@
 diff --git a/Dockerfile b/Dockerfile
-index 067c238..f1a9137 100644
+index 067c238..82d38c1 100644
 --- a/Dockerfile
 +++ b/Dockerfile
 @@ -13,7 +13,7 @@
@@ -26,3 +26,21 @@ index 067c238..f1a9137 100644
  
  # Retrieve the binary from the previous stage
  COPY --from=builder /opt/app-root/src/rekor-server /usr/local/bin/rekor-server
+@@ -40,12 +46,14 @@ COPY --from=builder /opt/app-root/src/rekor-server /usr/local/bin/rekor-server
+ CMD ["rekor-server", "serve"]
+ 
+ # debug compile options & debugger
+-FROM deploy as debug
+-RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
++FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as debug
++COPY --from=deploy /usr/local/bin/rekor-server /usr/local/bin/rekor-server
++RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.0
+ 
+ # overwrite server and include debugger
+ COPY --from=builder /opt/app-root/src/rekor-server_debug /usr/local/bin/rekor-server
+ 
+-FROM deploy as test
++FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as test
++COPY --from=deploy /usr/local/bin/rekor-server /usr/local/bin/rekor-server
+ # overwrite server with test build with code coverage
+ COPY --from=builder /opt/app-root/src/rekor-server_test /usr/local/bin/rekor-server

--- a/redhat/patches/0001-dockerfile.patch
+++ b/redhat/patches/0001-dockerfile.patch
@@ -7,7 +7,7 @@ index 067c238..82d38c1 100644
  # limitations under the License.
  
 -FROM golang:1.21.1@sha256:c416ceeec1cdf037b80baef1ccb402c230ab83a9134b34c0902c542eb4539c82 AS builder
-+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS builder
++FROM registry.access.redhat.com/ubi9/go-toolset@sha256:e91cbbd0b659498d029dd43e050c8a009c403146bfba22cbebca8bcd0ee7925f AS builder
  ENV APP_ROOT=/opt/app-root
  ENV GOPATH=$APP_ROOT
  
@@ -16,7 +16,7 @@ index 067c238..82d38c1 100644
  
  # Multi-Stage production build
 -FROM golang:1.21.1@sha256:c416ceeec1cdf037b80baef1ccb402c230ab83a9134b34c0902c542eb4539c82 as deploy
-+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as deploy
++FROM registry.access.redhat.com/ubi9/go-toolset@sha256:e91cbbd0b659498d029dd43e050c8a009c403146bfba22cbebca8bcd0ee7925f as deploy
 +
 +LABEL description="Rekor provides an immutable tamper resistant ledger of metadata generated within a software projects supply chain."
 +LABEL io.k8s.description="Rekor provides an immutable tamper resistant ledger of metadata generated within a software projects supply chain."
@@ -32,7 +32,7 @@ index 067c238..82d38c1 100644
  # debug compile options & debugger
 -FROM deploy as debug
 -RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
-+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as debug
++FROM registry.access.redhat.com/ubi9/go-toolset@sha256:e91cbbd0b659498d029dd43e050c8a009c403146bfba22cbebca8bcd0ee7925f as debug
 +COPY --from=deploy /usr/local/bin/rekor-server /usr/local/bin/rekor-server
 +RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.0
  
@@ -40,7 +40,7 @@ index 067c238..82d38c1 100644
  COPY --from=builder /opt/app-root/src/rekor-server_debug /usr/local/bin/rekor-server
  
 -FROM deploy as test
-+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as test
++FROM registry.access.redhat.com/ubi9/go-toolset@sha256:e91cbbd0b659498d029dd43e050c8a009c403146bfba22cbebca8bcd0ee7925f as test
 +COPY --from=deploy /usr/local/bin/rekor-server /usr/local/bin/rekor-server
  # overwrite server with test build with code coverage
  COPY --from=builder /opt/app-root/src/rekor-server_test /usr/local/bin/rekor-server


### PR DESCRIPTION
This pr introduces a fix for when RHTAP builds the rekor-server image, basically when RHTAP would try to build this Dockerfile, the pipeline was trying to pull an image called "[deploy](https://github.com/sigstore/rekor/blob/main/Dockerfile#L43)"  this fix changes the deploy image to use the ubi9 one used in the rest of the dockerfile, It also copy's everything from each stage so nothing is lost and the image builds in the same way it did before.


Update: Also updates sha to latest version to avoid cve errors in RHTAP (Probably needs to be done across the board)