### PR TITLE
Update v1.2.2 patch file with RHTAP compliant labels.

### DIFF
--- a/redhat/patches/0001-dockerfile.patch
+++ b/redhat/patches/0001-dockerfile.patch
@@ -1,28 +1,43 @@
 diff --git a/Dockerfile b/Dockerfile
-index f2d39ac..4d33566 100644
+index f2d39ac..ab77c76 100644
 --- a/Dockerfile
 +++ b/Dockerfile
 @@ -13,7 +13,7 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
- 
+
 -FROM golang:1.20.5@sha256:344193a70dc3588452ea39b4a1e465a8d3c91f788ae053f7ee168cebf18e0a50 AS builder
 +FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 AS builder
  ENV APP_ROOT=/opt/app-root
  ENV GOPATH=$APP_ROOT
- 
+
 @@ -31,7 +31,13 @@ RUN CGO_ENABLED=0 go build -gcflags "all=-N -l" -ldflags "${SERVER_LDFLAGS}" -o
  RUN go test -c -ldflags "${SERVER_LDFLAGS}" -cover -covermode=count -coverpkg=./... -o rekor-server_test ./cmd/rekor-server
- 
+
  # Multi-Stage production build
 -FROM golang:1.20.5@sha256:344193a70dc3588452ea39b4a1e465a8d3c91f788ae053f7ee168cebf18e0a50 as deploy
-+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:52ab391730a63945f61d93e8c913db4cc7a96f200de909cd525e2632055d9fa6 as deploy
++FROM registry.access.redhat.com/ubi9/go-toolset@sha256:e91cbbd0b659498d029dd43e050c8a009c403146bfba22cbebca8bcd0ee7925f AS deploy
 +
 +LABEL description="Rekor provides an immutable tamper resistant ledger of metadata generated within a software projects supply chain."
 +LABEL io.k8s.description="Rekor provides an immutable tamper resistant ledger of metadata generated within a software projects supply chain."
 +LABEL io.k8s.display-name="Rekor container image for Red Hat Trusted Signer"
 +LABEL io.openshift.tags="rekor trusted-signer"
 +LABEL summary="The rekor-server binary provides an immutable, tamper-resistant log."
- 
+
  # Retrieve the binary from the previous stage
  COPY --from=builder /opt/app-root/src/rekor-server /usr/local/bin/rekor-server
+@@ -40,12 +46,12 @@ COPY --from=builder /opt/app-root/src/rekor-server /usr/local/bin/rekor-server
+ CMD ["rekor-server", "serve"]
+
+ # debug compile options & debugger
+-FROM deploy as debug
++FROM registry.access.redhat.com/ubi9/go-toolset@sha256:e91cbbd0b659498d029dd43e050c8a009c403146bfba22cbebca8bcd0ee7925f AS debug
+ RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.0
+
+ # overwrite server and include debugger
+ COPY --from=builder /opt/app-root/src/rekor-server_debug /usr/local/bin/rekor-server
+
+-FROM deploy as test
++FROM registry.access.redhat.com/ubi9/go-toolset@sha256:e91cbbd0b659498d029dd43e050c8a009c403146bfba22cbebca8bcd0ee7925f AS test
+ # overwrite server with test build with code coverage
+ COPY --from=builder /opt/app-root/src/rekor-server_test /usr/local/bin/rekor-server


### PR DESCRIPTION
This is a backport of https://github.com/securesign/rekor/pull/72 to the midstream release branch.

/cc @JasonPowr ptal