### PR TITLE
SECURESIGN-115 | Add new label to dockerfiles for Comet

### DIFF
--- a/redhat/overlays/Dockerfile
+++ b/redhat/overlays/Dockerfile
@@ -54,6 +54,7 @@ LABEL io.k8s.description="Rekor-Server provides a tamper resistant ledger."
 LABEL io.k8s.display-name="Rekor-Server container image for Red Hat Trusted Signer"
 LABEL io.openshift.tags="rekor-server trusted-signer"
 LABEL summary="Provides the rekor Server binary for running Rekor-Server"
+LABEL com.redhat.component="rekor-server"
 
 COPY --from=deploy /usr/local/bin/rekor-server /usr/local/bin/rekor-server
 # overwrite server with test build with code coverage

--- a/redhat/overlays/Dockerfile.backfill-redis
+++ b/redhat/overlays/Dockerfile.backfill-redis
@@ -15,6 +15,7 @@ LABEL io.k8s.description="Backfillredis is a job that will go through the TLog a
 LABEL io.k8s.display-name="Backfillredis container image for Red Hat Trusted Signer"
 LABEL io.openshift.tags="backfill-redis trusted-signer"
 LABEL summary="Provides the backfill-redis binary for a rekor server"
+LABEL com.redhat.component="backfill-redis"
 
 #ENTRYPOINT
 ENTRYPOINT [ "backfill-redis" ]

--- a/redhat/overlays/Dockerfile.cli
+++ b/redhat/overlays/Dockerfile.cli
@@ -13,6 +13,7 @@ LABEL io.k8s.description="Rekor-cli is a command line interface (CLI) tool used 
 LABEL io.k8s.display-name="Rekor-cli container image for Red Hat Trusted Signer"
 LABEL io.openshift.tags="rekor-cli trusted-signer"
 LABEL summary="Provides the rekor CLI binary for interacting with a rekor server"
+LABEL com.redhat.component="rekor-cli"
 
 COPY --from=build-env /opt/app-root/src/rekor-cli /usr/local/bin/rekor-cli
 WORKDIR /opt/app-root/src/home


### PR DESCRIPTION
This pr is related to this issue https://issues.redhat.com/browse/SECURESIGN-115, and involves adding an extra label to the Dockerfiles for Comet.