### PR TITLE
chore: remove unit and e2e tests from the pipeline

### DIFF
--- a/.tekton/backfill-redis-pull-request.yaml
+++ b/.tekton/backfill-redis-pull-request.yaml
@@ -371,21 +371,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/rekor-unit-test@sha256:e2713945aa7f1a14bd58a0c809691325fa8070cf6d0a0e476cc9e485cc680826
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/rekor-unit-test@sha256:e2713945aa7f1a14bd58a0c809691325fa8070cf6d0a0e476cc9e485cc680826
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/backfill-redis-push.yaml
+++ b/.tekton/backfill-redis-push.yaml
@@ -368,21 +368,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/rekor-unit-test@sha256:e2713945aa7f1a14bd58a0c809691325fa8070cf6d0a0e476cc9e485cc680826
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/rekor-unit-test@sha256:e2713945aa7f1a14bd58a0c809691325fa8070cf6d0a0e476cc9e485cc680826
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/rekor-cli-pull-request.yaml
+++ b/.tekton/rekor-cli-pull-request.yaml
@@ -371,19 +371,19 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/rekor-unit-test@sha256:e2713945aa7f1a14bd58a0c809691325fa8070cf6d0a0e476cc9e485cc680826
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/rekor-unit-test@sha256:e2713945aa7f1a14bd58a0c809691325fa8070cf6d0a0e476cc9e485cc680826
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
         - name: source
           workspace: workspace
     workspaces:

--- a/.tekton/rekor-cli-push.yaml
+++ b/.tekton/rekor-cli-push.yaml
@@ -368,21 +368,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/rekor-unit-test@sha256:e2713945aa7f1a14bd58a0c809691325fa8070cf6d0a0e476cc9e485cc680826
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/rekor-unit-test@sha256:e2713945aa7f1a14bd58a0c809691325fa8070cf6d0a0e476cc9e485cc680826
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/rekor-server-pull-request.yaml
+++ b/.tekton/rekor-server-pull-request.yaml
@@ -371,54 +371,54 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - build-container    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/rekor-unit-test@sha256:e2713945aa7f1a14bd58a0c809691325fa8070cf6d0a0e476cc9e485cc680826
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
-    - name: build-test-image
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: build-test-image
-        - name: bundle
-          value: quay.io/securesign/rekor-build-test-image@sha256:44dade29f5022faff66eb552e1c1ba71698df8759b725f8550355ffcdd719709
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
-    - name: run-e2e-test
-      params:
-      - name: TEST_IMAGE_URL
-        value: $(tasks.build-test-image.results.TEST_IMAGE_URL)
-      runAfter:
-      - build-test-image  
-      taskRef:
-        params:
-        - name: name
-          value: rekor-e2e-test
-        - name: bundle
-          value: quay.io/securesign/rekor-e2e-test@sha256:2ef6fbab2f49508db9b999315792655ce732b876085d88c82227db8bbff9ee19
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - build-container
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/rekor-unit-test@sha256:e2713945aa7f1a14bd58a0c809691325fa8070cf6d0a0e476cc9e485cc680826
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
+    # - name: build-test-image
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: build-test-image
+    #     - name: bundle
+    #       value: quay.io/securesign/rekor-build-test-image@sha256:44dade29f5022faff66eb552e1c1ba71698df8759b725f8550355ffcdd719709
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
+    # - name: run-e2e-test
+    #   params:
+    #   - name: TEST_IMAGE_URL
+    #     value: $(tasks.build-test-image.results.TEST_IMAGE_URL)
+    #   runAfter:
+    #   - build-test-image
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: rekor-e2e-test
+    #     - name: bundle
+    #       value: quay.io/securesign/rekor-e2e-test@sha256:2ef6fbab2f49508db9b999315792655ce732b876085d88c82227db8bbff9ee19
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/rekor-server-push.yaml
+++ b/.tekton/rekor-server-push.yaml
@@ -368,21 +368,21 @@ spec:
         operator: in
         values:
         - "false"
-    - name: run-unit-test
-      runAfter:
-      - prefetch-dependencies    
-      taskRef:
-        params:
-        - name: name
-          value: go-unit-test
-        - name: bundle
-          value: quay.io/securesign/rekor-unit-test@sha256:e2713945aa7f1a14bd58a0c809691325fa8070cf6d0a0e476cc9e485cc680826
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-        - name: source
-          workspace: workspace
+    # - name: run-unit-test
+    #   runAfter:
+    #   - prefetch-dependencies
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: go-unit-test
+    #     - name: bundle
+    #       value: quay.io/securesign/rekor-unit-test@sha256:e2713945aa7f1a14bd58a0c809691325fa8070cf6d0a0e476cc9e485cc680826
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   workspaces:
+    #     - name: source
+    #       workspace: workspace
     workspaces:
     - name: workspace
     - name: git-auth


### PR DESCRIPTION
As of today, RHTAP does not allow unknown task images to run, causing a failure in the pipeline. We need to remove these tests temporarily until the RHTAP team can provide a way to support these.

Related Jira: https://issues.redhat.com/browse/EC-20