### PR TITLE
rhtap: update Dockerfile to get a clean git hash

### DIFF
--- a/redhat/overlays/Dockerfile.cli
+++ b/redhat/overlays/Dockerfile.cli
@@ -4,14 +4,16 @@ USER root
 RUN git config --global --add safe.directory /opt/app-root/src
 COPY . .
 
-RUN make Makefile.swagger
-RUN make -f Build.mak rekor-cli-darwin-amd64
-RUN make -f Build.mak rekor-cli-linux-amd64
-RUN make -f Build.mak rekor-cli-windows
-
-RUN gzip rekor_cli_darwin_amd64
-RUN gzip rekor_cli_linux_amd64
-RUN gzip rekor_cli_windows_amd64.exe
+RUN git stash && \
+    export GIT_VERSION=$(git describe --tags --always --dirty) && \
+    git stash pop && \
+    make Makefile.swagger && \
+    make -f Build.mak rekor-cli-darwin-amd64 && \
+    make -f Build.mak rekor-cli-linux-amd64 && \
+    make -f Build.mak rekor-cli-windows && \
+    gzip rekor_cli_darwin_amd64 && \
+    gzip rekor_cli_linux_amd64 && \
+    gzip rekor_cli_windows_amd64.exe
 
 #Install stage
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:b40f52aa68b29634ff45429ee804afbaa61b33de29ae775568933c71610f07a4


### PR DESCRIPTION
The cachi2 pipelinerun task in RHTAP modifies the Dockerfile to inject the cached dependency information into the build. This causes the git version - which is injected into the CLI version output - to include a `-dirty` suffix.

The modification in this commit stashes those changes, and then gets the git hash, storing it in the `GIT_VERSION` environment variable, then pops those changes back off of the stash and runs the build as before.

The commit also contains some optimizations so that most of the `RUN` commands are consolidated into one.