### PR TITLE
removing args on rhel9/redis-6 image

### DIFF
--- a/.tekton/rekor-e2e-test.yaml
+++ b/.tekton/rekor-e2e-test.yaml
@@ -1,0 +1,74 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: rekor-e2e-test
+  annotations:
+    tekton.dev/title: "Rekor e2e test"
+spec:
+  workspaces:
+    - name: source
+  params:
+    - name: TEST_IMAGE_URL
+      type: string
+      description: The image url for the test image
+      default: ""
+
+  sidecars:
+    - name: mysql
+      image: gcr.io/trillian-opensource-ci/db_server:v1.4.0
+      env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: zaphod
+        - name: MYSQL_DATABASE
+          value: test
+        - name: MYSQL_USER
+          value: test
+        - name: MYSQL_PASSWORD
+          value: zaphod
+
+    - name: redis-server
+      image: registry.redhat.io/rhel9/redis-6@sha256:031a5a63611e1e6a9fec47492a32347417263b79ad3b63bcee72fc7d02d64c94
+
+    - name: trillian-log-server
+      image: quay.io/redhat-user-workloads/rhtas-tenant/rhtas-stack-1-0-beta/trillian-logserver:build-58a79-1696502872
+      workingDir: $(workspaces.source.path)/source
+      command: 
+        - "/bin/sh"
+        - "-c"
+        - 'sleep 60 && /trillian_log_server --storage_system=mysql --mysql_uri="test:zaphod@tcp(127.0.0.1:3306)/test" --rpc_endpoint=0.0.0.0:8090 --http_endpoint=0.0.0.0:8091 --alsologtostderr'
+
+    - name: trillian-log-signer
+      image: quay.io/redhat-user-workloads/rhtas-tenant/rhtas-stack-1-0-beta/trillian-logsigner:build-38813-1696586021
+      workingDir: $(workspaces.source.path)/source
+      command: 
+        - "/bin/sh"
+        - "-c"
+        - 'sleep 60 && /trillian_log_signer --force_master --storage_system=mysql --mysql_uri="test:zaphod@tcp(127.0.0.1:3306)/test" --rpc_endpoint=0.0.0.0:8092 --http_endpoint=0.0.0.0:8093 --alsologtostderr'
+
+    - name: rekor-server
+      image: $(params.TEST_IMAGE_URL)
+      workingDir: $(workspaces.source.path)/source
+      command: 
+        - "/bin/sh"
+        - "-c"
+        - "sleep 80 && rekor-server -test.coverprofile=rekor-server.cov serve --trillian_log_server.address=127.0.0.1 --trillian_log_server.port=8090 --redis_server.address=127.0.0.1 --redis_server.port=6379 --rekor_server.address=0.0.0.0 --rekor_server.signer=memory --enable_attestation_storage --attestation_storage_bucket=file:///var/run/attestations --max_request_body_size=32792576"
+                
+  steps:
+    - name: run-e2e-test
+      image: $(params.TEST_IMAGE_URL)
+      workingDir: $(workspaces.source.path)/source
+      script: |
+        #!/usr/bin/env sh
+        chmod +x ./e2e-test.sh
+        ./e2e-test.sh
+      resources:
+        limits:
+          memory: 3Gi
+        requests:
+          memory: 512Mi
+
+# This file bundles the e2e tests for rekor. 
+# If any changes are made to this file, it must be pushed to Quay using the following command:
+# 'tkn bundle push quay.io/securesign/rekor-e2e-test:latest -f .tekton/rekor-e2e-test.yaml'.
+# This will generate a new SHA for the bundle. 
+# Ensure that this new SHA is updated in the pull and push pipeline files for each component.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,15 +31,7 @@ services:
       retries: 3
       start_period: 10s
   redis-server:
-    image: docker.io/redis:6.2
-    command: [
-      "--bind",
-      "0.0.0.0",
-      "--appendonly",
-      "yes",
-      "--requirepass",
-      "test"
-    ]
+    image: registry.redhat.io/rhel9/redis-6@sha256:031a5a63611e1e6a9fec47492a32347417263b79ad3b63bcee72fc7d02d64c94
     ports:
       - "6379:6379"
     restart: always # keep the redis server running


### PR DESCRIPTION
Related to same issue behind https://github.com/securesign/scaffolding/pull/125 and depends on it.

Dependency of certified helm charts (only use certified images check). If the implementation strategy gets approved by lance, then we will swap out the image that gets build from RHTAP once [scaffolding #125]( https://github.com/securesign/scaffolding/pull/125) gets merged. Because of that ...

/hold 