### PR TITLE
chore: copy overlays from midstream-v1.2.2

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -1,0 +1,59 @@
+
+# Set version variables for LDFLAGS
+GIT_VERSION ?= $(shell git describe --tags --always --dirty)
+GIT_HASH ?= $(shell git rev-parse HEAD)
+DATE_FMT = +%Y-%m-%dT%H:%M:%SZ
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+endif
+GIT_TREESTATE = "clean"
+DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
+ifeq ($(DIFF), 1)
+    GIT_TREESTATE = "dirty"
+endif
+
+GHCR_PREFIX ?= ghcr.io/sigstore/rekor
+GOBIN ?= $(shell go env GOPATH)/bin
+
+
+REKOR_LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_VERSION) \
+              -X sigs.k8s.io/release-utils/version.gitCommit=$(GIT_HASH) \
+              -X sigs.k8s.io/release-utils/version.gitTreeState=$(GIT_TREESTATE) \
+              -X sigs.k8s.io/release-utils/version.buildDate=$(BUILD_DATE)
+
+CLI_LDFLAGS=$(REKOR_LDFLAGS)
+SERVER_LDFLAGS=$(REKOR_LDFLAGS)
+
+.PHONY: 
+cross-platform: rekor-cli-darwin-arm64 rekor-cli-darwin-amd64 rekor-cli-linux-amd64 rekor-cli-linux-arm64 rekor-cli-linux-ppc64le rekor-cli-linux-s390x rekor-cli-windows ## Build all distributable (cross-platform) binaries
+
+.PHONY:	rekor-cli-darwin-arm64
+rekor-cli-darwin-arm64: $(SRCS)## Build for mac M1
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -v -o rekor_cli_darwin_arm64 -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
+
+.PHONY: rekor-cli-darwin-amd64
+rekor-cli-darwin-amd64:  $(SRCS)## Build for Darwin (macOS)
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o rekor_cli_darwin_amd64 -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
+
+.PHONY: rekor-cli-linux-amd64 
+rekor-cli-linux-amd64: $(SRCS)## Build for Linux amd64
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o rekor_cli_linux_amd64 -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
+
+.PHONY: rekor-cli-linux-arm64
+rekor-cli-linux-arm64: $(SRCS) ## Build for Linux arm64
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o rekor_cli_linux_arm64 -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
+
+.PHONY: rekor-cli-linux-ppc64le
+rekor-cli-linux-ppc64le: $(SRCS)## Build for Linux ppc64le
+	env CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -o rekor_cli_linux_ppc64le -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
+
+.PHONY: rekor-cli-linux-s390x
+rekor-cli-linux-s390x: $(SRCS) ## Build for Linux s390x
+	env CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -o rekor_cli_linux_s390x -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
+
+.PHONY: rekor-cli-windows
+rekor-cli-windows: $(SRCS) ## Build for Windows
+	env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o rekor_cli_windows_amd64.exe -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21.3@sha256:02d7116222536a5cf0fcf631f90b507758b669648e0f20186d2dc94a9b419a9b AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:c3a9c5c7fb226f6efcec2424dd30c38f652156040b490c9eca5ac5b61d8dc3ca AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 
@@ -30,22 +30,43 @@ RUN go build -ldflags "${SERVER_LDFLAGS}" ./cmd/rekor-server
 RUN CGO_ENABLED=0 go build -gcflags "all=-N -l" -ldflags "${SERVER_LDFLAGS}" -o rekor-server_debug ./cmd/rekor-server
 RUN go test -c -ldflags "${SERVER_LDFLAGS}" -cover -covermode=count -coverpkg=./... -o rekor-server_test ./cmd/rekor-server
 
+# debug compile options & debugger
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:c3a9c5c7fb226f6efcec2424dd30c38f652156040b490c9eca5ac5b61d8dc3ca as debug
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.0
+
+# overwrite server and include debugger
+COPY --from=builder /opt/app-root/src/rekor-server_debug /usr/local/bin/rekor-server
+
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:c3a9c5c7fb226f6efcec2424dd30c38f652156040b490c9eca5ac5b61d8dc3ca as test
+
+USER root
+
+# Extract the x86_64 minisign binary to /usr/local/bin/
+RUN curl -LO https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11-linux.tar.gz && \
+    tar -xzf minisign-0.11-linux.tar.gz minisign-linux/x86_64/minisign -O > /usr/local/bin/minisign && \
+    chmod +x /usr/local/bin/minisign && \
+    rm minisign-0.11-linux.tar.gz
+
+# Create test directory
+RUN mkdir -p /var/run/attestations && \
+    touch /var/run/attestations/attestation.json && \
+    chmod 777 /var/run/attestations/attestation.json
+
+# overwrite server with test build with code coverage
+COPY --from=builder /opt/app-root/src/rekor-server_test /usr/local/bin/rekor-server
+
 # Multi-Stage production build
-FROM golang:1.21.3@sha256:02d7116222536a5cf0fcf631f90b507758b669648e0f20186d2dc94a9b419a9b as deploy
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7d1ea7ac0c6f464dac7bae6994f1658172bf6068229f40778a513bc90f47e624 as deploy
+
+LABEL description="Rekor aims to provide an immutable, tamper-resistant ledger of metadata generated within a software project’s supply chain."
+LABEL io.k8s.description="Rekor-Server provides a tamper resistant ledger."
+LABEL io.k8s.display-name="Rekor-Server container image for Red Hat Trusted Signer"
+LABEL io.openshift.tags="rekor-server trusted-signer"
+LABEL summary="Provides the rekor Server binary for running Rekor-Server"
+LABEL com.redhat.component="rekor-server"
 
 # Retrieve the binary from the previous stage
 COPY --from=builder /opt/app-root/src/rekor-server /usr/local/bin/rekor-server
 
 # Set the binary as the entrypoint of the container
-CMD ["rekor-server", "serve"]
-
-# debug compile options & debugger
-FROM deploy as debug
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
-
-# overwrite server and include debugger
-COPY --from=builder /opt/app-root/src/rekor-server_debug /usr/local/bin/rekor-server
-
-FROM deploy as test
-# overwrite server with test build with code coverage
-COPY --from=builder /opt/app-root/src/rekor-server_test /usr/local/bin/rekor-server
+ENTRYPOINT ["rekor-server"]

--- a/Dockerfile.backfill-redis
+++ b/Dockerfile.backfill-redis
@@ -1,0 +1,21 @@
+#Build stage
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:c3a9c5c7fb226f6efcec2424dd30c38f652156040b490c9eca5ac5b61d8dc3ca AS build-env
+USER root
+RUN git config --global --add safe.directory /opt/app-root/src
+COPY . .
+RUN make backfill-redis
+
+#Install stage
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7d1ea7ac0c6f464dac7bae6994f1658172bf6068229f40778a513bc90f47e624
+COPY --from=build-env /opt/app-root/src/backfill-redis /usr/local/bin/backfill-redis
+WORKDIR /opt/app-root/src/home
+
+LABEL description="Backfillredis is a job that will go through the TLog and make sure that missing entries are added to the search index."
+LABEL io.k8s.description="Backfillredis is a job that will go through the TLog and make sure that missing entries are added to the search index."
+LABEL io.k8s.display-name="Backfillredis container image for Red Hat Trusted Signer"
+LABEL io.openshift.tags="backfill-redis trusted-signer"
+LABEL summary="Provides the backfill-redis binary for a rekor server"
+LABEL com.redhat.component="backfill-redis"
+
+#ENTRYPOINT
+ENTRYPOINT [ "backfill-redis" ]

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,0 +1,33 @@
+#Build stage
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:c3a9c5c7fb226f6efcec2424dd30c38f652156040b490c9eca5ac5b61d8dc3ca AS build-env
+USER root
+RUN git config --global --add safe.directory /opt/app-root/src
+COPY . .
+
+RUN git stash && \
+    export GIT_VERSION=$(git describe --tags --always --dirty) && \
+    git stash pop && \
+    make Makefile.swagger && \
+    make -f Build.mak rekor-cli-darwin-amd64 && \
+    make -f Build.mak rekor-cli-linux-amd64 && \
+    make -f Build.mak rekor-cli-windows && \
+    gzip rekor_cli_darwin_amd64 && \
+    gzip rekor_cli_linux_amd64 && \
+    gzip rekor_cli_windows_amd64.exe
+
+#Install stage
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7d1ea7ac0c6f464dac7bae6994f1658172bf6068229f40778a513bc90f47e624
+
+LABEL description="Rekor-cli is a command line interface (CLI) tool used to interact with a rekor server."
+LABEL io.k8s.description="Rekor-cli is a command line interface (CLI) tool used to interact with a rekor server."
+LABEL io.k8s.display-name="Rekor-cli container image for Red Hat Trusted Signer"
+LABEL io.openshift.tags="rekor-cli trusted-signer"
+LABEL summary="Provides the rekor CLI binary for interacting with a rekor server"
+LABEL com.redhat.component="rekor-cli"
+
+COPY --from=build-env /opt/app-root/src/rekor_cli_darwin_amd64.gz /usr/local/bin/rekor_cli_darwin_amd64.gz
+COPY --from=build-env /opt/app-root/src/rekor_cli_linux_amd64.gz /usr/local/bin/rekor_cli_linux_amd64.gz
+COPY --from=build-env /opt/app-root/src/rekor_cli_windows_amd64.exe.gz /usr/local/bin/rekor_cli_windows_amd64.exe.gz
+WORKDIR /opt/app-root/src/home
+
+

--- a/cmd/rekor-server/e2e_test.go
+++ b/cmd/rekor-server/e2e_test.go
@@ -35,6 +35,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"os/exec"
 
 	"github.com/sigstore/rekor/pkg/sharding"
 
@@ -226,8 +227,24 @@ func TestSearchNoEntriesRC1(t *testing.T) {
 	util.RunCliErr(t, "search", "--email", "noone@internetz.com")
 }
 func TestHostnameInSTH(t *testing.T) {
-	// get ID of container
-	rekorContainerID := strings.Trim(util.Run(t, "", "docker", "ps", "-q", "-f", "name=rekor-server"), "\n")
+	var rekorContainerID string
+
+	// Check if Docker is running
+	cmd := exec.Command("docker", "info")
+	err := cmd.Run()
+
+	if err != nil {
+		cmd := exec.Command("uname", "-n")
+		output, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("Failed to get hostname: %v", err)
+		}
+		rekorContainerID = strings.Trim(string(output), "\n")
+	} else {
+		// If Docker is running, get the container ID of rekor-server
+		rekorContainerID = strings.Trim(util.Run(t, "", "docker", "ps", "-q", "-f", "name=rekor-server"), "\n")
+	}
+
 	resp, err := http.Get(fmt.Sprintf("%s/api/v1/log", rekorServer()))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Since we are foregoing the use of update-to-head.sh for this next release, these overlays only need to be applied once, when the branch is created.