### PR TITLE
chore: bump go version of base image to 1.21

### DIFF
--- a/Dockerfile.backfill-redis
+++ b/Dockerfile.backfill-redis
@@ -1,9 +1,13 @@
 #Build stage
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:c3a9c5c7fb226f6efcec2424dd30c38f652156040b490c9eca5ac5b61d8dc3ca AS build-env
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder@sha256:98a0ff138c536eee98704d6909699ad5d0725a20573e2c510a60ef462b45cce0 AS build-env
 USER root
+ENV APP_ROOT=/opt/app-root
+
+WORKDIR $APP_ROOT/src/
+
 RUN git config --global --add safe.directory /opt/app-root/src
-COPY . .
-RUN make backfill-redis
+ADD . .
+RUN go mod tidy && go mod vendor && make backfill-redis
 
 #Install stage
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7d1ea7ac0c6f464dac7bae6994f1658172bf6068229f40778a513bc90f47e624

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,12 +1,18 @@
 #Build stage
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:c3a9c5c7fb226f6efcec2424dd30c38f652156040b490c9eca5ac5b61d8dc3ca AS build-env
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder@sha256:98a0ff138c536eee98704d6909699ad5d0725a20573e2c510a60ef462b45cce0 AS build-env
 USER root
+
+RUN mkdir /opt/app-root && mkdir /opt/app-root/src
+
+WORKDIR /opt/app-root/src
+
 RUN git config --global --add safe.directory /opt/app-root/src
 COPY . .
 
 RUN git stash && \
     export GIT_VERSION=$(git describe --tags --always --dirty) && \
     git stash pop && \
+    go mod vendor && \
     make Makefile.swagger && \
     make -f Build.mak rekor-cli-darwin-amd64 && \
     make -f Build.mak rekor-cli-linux-amd64 && \


### PR DESCRIPTION
Similar to: https://github.com/securesign/scaffolding/pull/132 but for rekor.

Fixes build issues based on go version in the base image.

/cc @lance 