### PR TITLE
enable hermetic builds

### DIFF
--- a/.tekton/backfill-redis-1-0-gamma-pull-request.yaml
+++ b/.tekton/backfill-redis-1-0-gamma-pull-request.yaml
@@ -30,6 +30,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: hermetic
+    value: "true"
+  # - name: prefetch-input
+  #   value: '{"path": ".","type": "gomod"}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/backfill-redis-1-0-gamma-push.yaml
+++ b/.tekton/backfill-redis-1-0-gamma-push.yaml
@@ -27,6 +27,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: hermetic
+    value: "true"
+  # - name: prefetch-input
+  #   value: '{"path": ".","type": "gomod"}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/rekor-server-1-0-gamma-pull-request.yaml
+++ b/.tekton/rekor-server-1-0-gamma-pull-request.yaml
@@ -30,6 +30,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: hermetic
+    value: "true"
+  # - name: prefetch-input
+  #   value: '{"path": ".","type": "gomod"}'
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/rekor-server-1-0-gamma-push.yaml
+++ b/.tekton/rekor-server-1-0-gamma-push.yaml
@@ -27,6 +27,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: hermetic
+    value: "true"
+  # - name: prefetch-input
+  #   value: '{"path": ".","type": "gomod"}'
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
This should enable hermetic builds. Prefetch dependencies was added but commented out until we get an update to the task for go version 1.21.

/cc @lance 