### PR TITLE
[SECURESIGN-247] Adding necessary files for build and RHTAP Onboarding

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+*Makefile.swagger


### PR DESCRIPTION
Having the Makefile.swagger get copied into the image was causing the build to hang so ive added a docker ignore as the file is regenerated anyways.