### PR TITLE
Updating Dockerfile with extra go mod vendor.

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -9,6 +9,9 @@ WORKDIR /opt/app-root/src
 RUN git config --global --add safe.directory /opt/app-root/src
 COPY . .
 
+WORKDIR /opt/app-root/src/hack/toolset
+RUN go mod vendor
+
 RUN git stash && \
     export GIT_VERSION=$(git describe --tags --always --dirty) && \
     git stash pop && \

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -12,6 +12,7 @@ COPY . .
 WORKDIR /opt/app-root/src/hack/toolset
 RUN go mod vendor
 
+WORKDIR /opt/app-root/src
 RUN git stash && \
     export GIT_VERSION=$(git describe --tags --always --dirty) && \
     git stash pop && \


### PR DESCRIPTION
There was an extra go.mod file in hacks/tools that I missed on the config that was causing swagger make targets to fail.