### PR TITLE
Update branch names

### DIFF
--- a/.github/workflows/cronjobs.yaml
+++ b/.github/workflows/cronjobs.yaml
@@ -33,7 +33,7 @@ jobs:
     uses: securesign/actions/.github/workflows/check-image-version.yaml@main
     strategy:
       matrix:
-        branch: [redhat-v1.2.2, redhat-v1.3]
+        branch: [main, redhat-v1.3]
     with:
       branch: ${{ matrix.branch }}
     secrets:


### PR DESCRIPTION
Small pr to keep image sha's updated in release branches, I've also changed the action to be a bit more flexible with the images , so once we can get a proper go-lang 1.21 image that can be updated too, will follow up with the other repos.