### PR TITLE
fix: Re Add check-image-version Cron job

### DIFF
--- a/.github/workflows/cronjob.yaml
+++ b/.github/workflows/cronjob.yaml
@@ -1,0 +1,17 @@
+name: GH Actions Cron Schedule
+on:
+  workflow_dispatch:
+  schedule:
+    # Every M-F at 12:00am run this job
+    - cron:  "0 0 * * 1-5"
+    
+jobs:
+  check-image-version:
+    uses: securesign/actions/.github/workflows/check-image-version.yaml@main
+    strategy:
+      matrix:
+        branch: [main, redhat-v1.3]
+    with:
+      branch: ${{ matrix.branch }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Small pr to re add the check-image-version Cron job, because we merge changes from our previous release branch these changes are lost as they lived in main