### PR TITLE
chore: use upstream redis for GitHub e2e tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,15 @@ services:
       retries: 3
       start_period: 10s
   redis-server:
-    image: registry.redhat.io/rhel9/redis-6@sha256:031a5a63611e1e6a9fec47492a32347417263b79ad3b63bcee72fc7d02d64c94
+    image: docker.io/redis:6.2
+    command: [
+      "--bind",
+      "0.0.0.0",
+      "--appendonly",
+      "yes",
+      "--requirepass",
+      "test"
+    ]
     ports:
       - "6379:6379"
     restart: always # keep the redis server running


### PR DESCRIPTION
We are running Rekor end to end tests in Konflux testing our images and stack. This change to the docker compose file should only affect GitHub Actions e2e tests.

This partially reverts https://github.com/securesign/rekor/pull/159

//cc @Gregory-Pereira 