### PR TITLE
pulling in upstream versioning

### DIFF
--- a/cmd/rekor-cli/app/version.go
+++ b/cmd/rekor-cli/app/version.go
@@ -16,7 +16,7 @@
 package app
 
 import (
-	"sigs.k8s.io/release-utils/version"
+	version "github.com/securesign/rekor/cmd/rekor-cli/app/version"
 )
 
 func init() {

--- a/cmd/rekor-cli/app/version/command.go
+++ b/cmd/rekor-cli/app/version/command.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Version returns a cobra command to be added to another cobra command, like:
+// ```go
+//
+//	rootCmd.AddCommand(version.Version())
+//
+// ```
+func Version() *cobra.Command {
+	return version("")
+}
+
+// WithFont returns a cobra command to be added to another cobra command with a select font for ASCII, like:
+// ```go
+//
+//	rootCmd.AddCommand(version.WithFont("starwars"))
+//
+// ```
+func WithFont(fontName string) *cobra.Command {
+	return version(fontName)
+}
+
+func version(fontName string) *cobra.Command {
+	var outputJSON bool
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Prints the version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := GetVersionInfo()
+			v.Name = cmd.Root().Name()
+			v.Description = cmd.Root().Short
+
+			v.FontName = ""
+			if fontName != "" && v.CheckFontName(fontName) {
+				v.FontName = fontName
+			}
+			cmd.SetOut(cmd.OutOrStdout())
+
+			if outputJSON {
+				out, err := v.JSONString()
+				if err != nil {
+					return fmt.Errorf("unable to generate JSON from version info: %w", err)
+				}
+				cmd.Println(out)
+			} else {
+				cmd.Println(v.String())
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&outputJSON, "json", false, "print JSON instead of text")
+
+	return cmd
+}

--- a/cmd/rekor-cli/app/version/command_test.go
+++ b/cmd/rekor-cli/app/version/command_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version_test
+
+import (
+	"testing"
+
+	"sigs.k8s.io/release-utils/version"
+)
+
+func TestVersion(t *testing.T) {
+	v := version.Version()
+	err := v.Execute()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+}
+
+func TestVersionWithFont(t *testing.T) {
+	v := version.WithFont("fender")
+	err := v.Execute()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+}
+
+func TestVersionJson(t *testing.T) {
+	v := version.Version()
+	v.SetArgs([]string{"--json"})
+	err := v.Execute()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+}

--- a/cmd/rekor-cli/app/version/doc.go
+++ b/cmd/rekor-cli/app/version/doc.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package version provides an importable cobra command and a fixed package
+// path location to set compile time version information. To override the
+// default values, set the `-ldflags` flags with the following strings:
+//
+// sigs.k8s.io/release-utils/version.gitVersion=<GitVersion>
+// sigs.k8s.io/release-utils/version.gitCommit=<GitCommit>
+// sigs.k8s.io/release-utils/version.gitTreeState=<GitTreeState>
+// sigs.k8s.io/release-utils/version.buildDate=<BuildDate>
+//
+// Example: `go build -ldflags " -X sigs.k8s.io/release-utils/version.gitVersion=v0.4.0-1-g040f53c -X sigs.k8s.io/release-utils/version.gitCommit=040f53c -X sigs.k8s.io/release-utils/version.gitTreeState=dirty -X sigs.k8s.io/release-utils/version.buildDate=2022-02-03T17:30:01Z" .`
+package version

--- a/cmd/rekor-cli/app/version/version.go
+++ b/cmd/rekor-cli/app/version/version.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"text/tabwriter"
+	"time"
+
+	"github.com/common-nighthawk/go-figure"
+)
+
+const unknown = "unknown"
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via go ldflags.
+var (
+	// Output of "git describe". The prerequisite is that the
+	// branch should be tagged using the correct versioning strategy.
+	gitVersion = "devel"
+	// SHA1 from git, output of $(git rev-parse HEAD)
+	gitCommit = unknown
+	// State of git tree, either "clean" or "dirty"
+	gitTreeState = unknown
+	// Build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate = unknown
+	// flag to print the ascii name banner
+	asciiName = "true"
+	// goVersion is the used golang version.
+	goVersion = unknown
+	// compiler is the used golang compiler.
+	compiler = unknown
+	// platform is the used os/arch identifier.
+	platform     = unknown
+	rhtasVersion = unknown
+
+	once sync.Once
+	info = Info{}
+)
+
+type Info struct {
+	GitVersion   string `json:"gitVersion"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	BuildDate    string `json:"buildDate"`
+	GoVersion    string `json:"goVersion"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
+	RhtasVersion string `json:"rhtasVersion`
+
+	ASCIIName   string `json:"-"`
+	FontName    string `json:"-"`
+	Name        string `json:"-"`
+	Description string `json:"-"`
+}
+
+func getBuildInfo() *debug.BuildInfo {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+	return bi
+}
+
+func getGitVersion(bi *debug.BuildInfo) string {
+	if bi == nil {
+		return unknown
+	}
+
+	// TODO: remove this when the issue https://github.com/golang/go/issues/29228 is fixed
+	if bi.Main.Version == "(devel)" || bi.Main.Version == "" {
+		return gitVersion
+	}
+
+	return bi.Main.Version
+}
+
+func getCommit(bi *debug.BuildInfo) string {
+	return getKey(bi, "vcs.revision")
+}
+
+func getDirty(bi *debug.BuildInfo) string {
+	modified := getKey(bi, "vcs.modified")
+	if modified == "true" {
+		return "dirty"
+	}
+	if modified == "false" {
+		return "clean"
+	}
+	return unknown
+}
+
+func getBuildDate(bi *debug.BuildInfo) string {
+	buildTime := getKey(bi, "vcs.time")
+	t, err := time.Parse("2006-01-02T15:04:05Z", buildTime)
+	if err != nil {
+		return unknown
+	}
+	return t.Format("2006-01-02T15:04:05")
+}
+
+func getKey(bi *debug.BuildInfo, key string) string {
+	if bi == nil {
+		return unknown
+	}
+	for _, iter := range bi.Settings {
+		if iter.Key == key {
+			return iter.Value
+		}
+	}
+	return unknown
+}
+
+func getRHTASVersion() string {
+	//  Set version here
+	return "v1.0.0"
+}
+
+// GetVersionInfo represents known information on how this binary was built.
+func GetVersionInfo() Info {
+	once.Do(func() {
+		buildInfo := getBuildInfo()
+		gitVersion = getGitVersion(buildInfo)
+		if gitCommit == unknown {
+			gitCommit = getCommit(buildInfo)
+		}
+
+		if gitTreeState == unknown {
+			gitTreeState = getDirty(buildInfo)
+		}
+
+		if buildDate == unknown {
+			buildDate = getBuildDate(buildInfo)
+		}
+
+		if goVersion == unknown {
+			goVersion = runtime.Version()
+		}
+
+		if compiler == unknown {
+			compiler = runtime.Compiler
+		}
+
+		if platform == unknown {
+			platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+		}
+
+		if rhtasVersion == unknown {
+			rhtasVersion = getRHTASVersion()
+		}
+
+		info = Info{
+			ASCIIName:    asciiName,
+			GitVersion:   gitVersion,
+			GitCommit:    gitCommit,
+			GitTreeState: gitTreeState,
+			BuildDate:    buildDate,
+			GoVersion:    goVersion,
+			Compiler:     compiler,
+			Platform:     platform,
+			RhtasVersion: rhtasVersion,
+		}
+	})
+
+	return info
+}
+
+// String returns the string representation of the version info
+func (i *Info) String() string {
+	b := strings.Builder{}
+	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+
+	// name and description are optional.
+	if i.Name != "" {
+		if i.ASCIIName == "true" {
+			f := figure.NewFigure(strings.ToUpper(i.Name), i.FontName, true)
+			_, _ = fmt.Fprint(w, f.String())
+		}
+		_, _ = fmt.Fprint(w, i.Name)
+		if i.Description != "" {
+			_, _ = fmt.Fprintf(w, ": %s", i.Description)
+		}
+		_, _ = fmt.Fprint(w, "\n\n")
+	}
+
+	_, _ = fmt.Fprintf(w, "GitVersion:\t%s\n", i.GitVersion)
+	_, _ = fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
+	_, _ = fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)
+	_, _ = fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)
+	_, _ = fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
+	_, _ = fmt.Fprintf(w, "Compiler:\t%s\n", i.Compiler)
+	_, _ = fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
+
+	_ = w.Flush()
+	return b.String()
+}
+
+// JSONString returns the JSON representation of the version info
+func (i *Info) JSONString() (string, error) {
+	b, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}
+
+func (i *Info) CheckFontName(fontName string) bool {
+	assetNames := figure.AssetNames()
+
+	for _, font := range assetNames {
+		if strings.Contains(font, fontName) {
+			return true
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, "font not valid, using default")
+	return false
+}

--- a/cmd/rekor-cli/app/version/version_test.go
+++ b/cmd/rekor-cli/app/version/version_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionText(t *testing.T) {
+	sut := GetVersionInfo()
+	require.NotEmpty(t, sut.String())
+}
+
+func TestVersionJSON(t *testing.T) {
+	sut := GetVersionInfo()
+	json, err := sut.JSONString()
+
+	require.Nil(t, err)
+	require.NotEmpty(t, json)
+}

--- a/go.mod
+++ b/go.mod
@@ -128,6 +128,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
@@ -186,6 +187,7 @@ require (
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
+	github.com/stretchr/testify v1.8.4
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/ulikunitz/xz v0.5.11 // indirect


### PR DESCRIPTION
versioning module needed to be pulled in from: https://github.com/sigstore/rekor/blob/main/cmd/rekor-cli/app/version.go#L19
This should allow us to modify it to include downstream build information. We will then pull it in in cosign and gistign.