### PR TITLE
Add TLS support for Trillian server (#2164)

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -117,6 +117,8 @@ Memory and file-based signers should only be used for testing.`)
 	rootCmd.PersistentFlags().String("redis_server.password", "", "Redis server password")
 	rootCmd.PersistentFlags().Bool("redis_server.enable-tls", false, "Whether to enable TLS verification when connecting to Redis endpoint")
 	rootCmd.PersistentFlags().Bool("redis_server.insecure-skip-verify", false, "Whether to skip TLS verification when connecting to Redis endpoint, only applicable when 'redis_server.enable-tls' is set to 'true'")
+	rootCmd.PersistentFlags().String("trillian_log_server.tls_ca_cert", "", "Certificate file to use for secure connections with Trillian server")
+	rootCmd.PersistentFlags().Bool("trillian_log_server.tls", false, "Use TLS when connecting to Trillian Server")
 
 	rootCmd.PersistentFlags().Bool("enable_attestation_storage", false, "enables rich attestation storage")
 	rootCmd.PersistentFlags().String("attestation_storage_bucket", "", "url for attestation storage bucket")


### PR DESCRIPTION
#### Summary
This pull request introduces support for enabling TLS in communications with the Trillian server. By adding a new command-line flag `--trillian_log_server.tls_ca_cert` and implementing the necessary logic to handle TLS certificates, this update enhances the security of Rekor.


#### Release Note

- Feature: Added support for TLS in communication with the Trillian server.
- New Flag: 
   - `--trillian_log_server.tls_ca_cert` to specify the CA certificate file path for secure connections.
 
Resolves Issue: https://github.com/sigstore/rekor/issues/2163
