### PR TITLE
chore(license): ignore the policy-data directory

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Check license headers
         run: |
           set -e
-          addlicense -l apache -c 'The Sigstore Authors' -v *
+          addlicense -ignore policy-data/** -l apache -c 'The Sigstore Authors' -v *
           git diff --exit-code
 
   golangci:


### PR DESCRIPTION
Modifies the upstream verfication task so that it ignores the `policy-data` directory, which is added for downstream builds.