### PR TITLE
Removing Renovate as it is uneeded

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "github>securesign/actions:centralRenovate.json"
-    ]
-}


### PR DESCRIPTION
Konflux uses the inherited config approach which requires a repo within our org containing a specific config. Which has now been created.