### PR TITLE
feat(fips): upgrade Go to 1.24

### DIFF
--- a/.tekton/backfill-redis-pull-request.yaml
+++ b/.tekton/backfill-redis-pull-request.yaml
@@ -41,8 +41,6 @@ spec:
     value: '[{"path":".","type":"gomod"},{"path":"./hack/tools","type":"gomod"}]'
   - name: go_unit_test
     value: "true"
-  - name: go_base_image
-    value: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
   pipelineRef:
     params:
     - name: url

--- a/.tekton/backfill-redis-push.yaml
+++ b/.tekton/backfill-redis-push.yaml
@@ -39,8 +39,6 @@ spec:
     value: '[{"path":".","type":"gomod"},{"path":"./hack/tools","type":"gomod"}]'
   - name: go_unit_test
     value: "true"
-  - name: go_base_image
-    value: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
   pipelineRef:
     params:
     - name: url

--- a/.tekton/rekor-cli-pull-request.yaml
+++ b/.tekton/rekor-cli-pull-request.yaml
@@ -41,8 +41,6 @@ spec:
     value: "true"
   - name: go_unit_test
     value: "true"
-  - name: go_base_image
-    value: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
   pipelineRef:
     params:
     - name: url

--- a/.tekton/rekor-cli-push.yaml
+++ b/.tekton/rekor-cli-push.yaml
@@ -38,8 +38,6 @@ spec:
     value: "true"
   - name: go_unit_test
     value: "true"
-  - name: go_base_image
-    value: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
   pipelineRef:
     params:
     - name: url

--- a/.tekton/rekor-server-pull-request.yaml
+++ b/.tekton/rekor-server-pull-request.yaml
@@ -41,8 +41,6 @@ spec:
     value: '[{"path":".","type":"gomod"},{"path":"./hack/tools","type":"gomod"}]'
   - name: go_unit_test
     value: "true"
-  - name: go_base_image
-    value: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
   pipelineRef:
     params:
     - name: url

--- a/.tekton/rekor-server-push.yaml
+++ b/.tekton/rekor-server-push.yaml
@@ -39,8 +39,6 @@ spec:
     value: '[{"path":".","type":"gomod"},{"path":"./hack/tools","type":"gomod"}]'
   - name: go_unit_test
     value: "true"
-  - name: go_base_image
-    value: brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:44fd8f88f3b6463cda15571260f9ca3a0b78d3c8c8827a338e04ab3a23581a88
   pipelineRef:
     params:
     - name: url

--- a/Dockerfile.backfill-redis.rh
+++ b/Dockerfile.backfill-redis.rh
@@ -1,17 +1,21 @@
 # Build stage
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS build-env
+
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
+
 USER root
-RUN mkdir /opt/app-root && mkdir /opt/app-root/src && git config --global --add safe.directory /opt/app-root/src
+RUN mkdir -p /opt/app-root && mkdir -p /opt/app-root/src && git config --global --add safe.directory /opt/app-root/src
 
 WORKDIR /opt/app-root/src/
 COPY . .
 
-RUN CGO_ENABLED=0 go mod download
+RUN go mod download
 
 
 ARG SERVER_LDFLAGS
-RUN CGO_ENABLED=0 go build -mod=readonly -trimpath -ldflags "$(SERVER_LDFLAGS)" -o backfill-redis ./cmd/backfill-index
+RUN go build -mod=readonly -trimpath -ldflags "$(SERVER_LDFLAGS)" -o backfill-redis ./cmd/backfill-index
 
 # Install stage
 FROM registry.redhat.io/rhel9/redis-6@sha256:148554aca88b1d5dccf68edcee65309240b1b0720bd0500a101e063db2d2030f

--- a/Dockerfile.rekor-cli.rh
+++ b/Dockerfile.rekor-cli.rh
@@ -1,8 +1,10 @@
 #Build stage#
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS build-env
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
 USER root
 
-RUN mkdir /opt/app-root && mkdir /opt/app-root/src && git config --global --add safe.directory /opt/app-root/src
+RUN mkdir -p /opt/app-root && mkdir -p /opt/app-root/src && git config --global --add safe.directory /opt/app-root/src
 
 WORKDIR /opt/app-root/src
 

--- a/Dockerfile.rekor-server.rh
+++ b/Dockerfile.rekor-server.rh
@@ -13,17 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 AS build-env
 
-RUN mkdir /opt/app-root && mkdir /opt/app-root/src && mkdir /opt/app-root/src/cmd && mkdir /opt/app-root/src/pkg && git config --global --add safe.directory /opt/app-root/src
+RUN mkdir -p /opt/app-root && mkdir -p /opt/app-root/src && mkdir -p /opt/app-root/src/cmd && mkdir -p /opt/app-root/src/pkg && git config --global --add safe.directory /opt/app-root/src
 
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
-
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
 
 WORKDIR $APP_ROOT/src/
 ADD go.mod go.sum $APP_ROOT/src/
-RUN CGO_ENABLED=0 go mod download
+RUN go mod download
 
 # Add source code
 ADD ./cmd/ $APP_ROOT/src/cmd/
@@ -31,7 +32,7 @@ ADD ./pkg/ $APP_ROOT/src/pkg/
 
 ARG SERVER_LDFLAGS
 RUN go build -ldflags "${SERVER_LDFLAGS}" -mod=readonly ./cmd/rekor-server
-RUN CGO_ENABLED=0 go build -gcflags "all=-N -l" -ldflags "${SERVER_LDFLAGS}" -o rekor-server_debug -mod=readonly ./cmd/rekor-server
+RUN go build -gcflags "all=-N -l" -ldflags "${SERVER_LDFLAGS}" -o rekor-server_debug -mod=readonly ./cmd/rekor-server
 RUN go test -c -ldflags "${SERVER_LDFLAGS}" -cover -covermode=count -coverpkg=./... -o rekor-server_test -mod=readonly ./cmd/rekor-server
 
 # debug compile options & debugger


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Go to 1.24 across the project

Build:
- Standardize all Dockerfiles to use the golang:1.24 base image in builder and deploy stages
- Update go.mod to target Go 1.24 and bump the toolchain to go1.24.4