### PR TITLE
fix: skips the GCP-dependent build job in forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ on:
 jobs:
   build:
     name: build
+    # RHTAS - Skipping due to auth with google
+    if: github.repository == 'sigstore/rekor'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
- This PR updates the build.yml workflow so that the container build job only runs in the upstream sigstore/rekor repository. This prevents failures in forks or mirrors (such as securesign/rekor) that do not have access to the required Google Cloud resources for image publishing.

## Summary by Sourcery

Prevent build failures in forks by only executing the container build step in the upstream sigstore/rekor repository

Bug Fixes:
- Skip the GCP-dependent build job in forks to prevent failures due to missing Google Cloud access

CI:
- Add a GitHub Actions conditional to run the build job only in the sigstore/rekor repository