### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for rekor-server

### DIFF
--- a/Dockerfile.rekor-server.rh
+++ b/Dockerfile.rekor-server.rh
@@ -69,7 +69,8 @@ LABEL io.k8s.display-name="Rekor-Server container image for Red Hat Trusted Sign
 LABEL io.openshift.tags="rekor-server trusted-signer"
 LABEL summary="Provides the rekor Server binary for running Rekor-Server"
 LABEL com.redhat.component="rekor-server"
-LABEL name="rekor-server"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
+LABEL name="rhtas/rekor-server-rhel9"
 
 # Retrieve the binary from the previous stage
 COPY --from=build-env /opt/app-root/src/rekor-server /usr/local/bin/rekor-server


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
