### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for backfill-redis

### DIFF
--- a/Dockerfile.backfill-redis.rh
+++ b/Dockerfile.backfill-redis.rh
@@ -28,7 +28,8 @@ LABEL io.k8s.display-name="Backfillredis container image for Red Hat Trusted Sig
 LABEL io.openshift.tags="backfill-redis trusted-signer"
 LABEL summary="Provides the backfill-redis binary for a rekor server"
 LABEL com.redhat.component="backfill-redis"
-LABEL name="backfill-redis"
+LABEL name="rhtas/rekor-backfill-redis-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 #ENTRYPOINT
 ENTRYPOINT [ "backfill-redis" ]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
