### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for rekor-cli

### DIFF
--- a/Dockerfile.rekor-cli.rh
+++ b/Dockerfile.rekor-cli.rh
@@ -39,7 +39,8 @@ LABEL io.k8s.display-name="Rekor-cli container image for Red Hat Trusted Signer"
 LABEL io.openshift.tags="rekor-cli trusted-signer"
 LABEL summary="Provides the rekor CLI binary for interacting with a rekor server"
 LABEL com.redhat.component="rekor-cli"
-LABEL name="rekor-cli"
+LABEL name="rhtas/rekor-cli-rhel9"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 COPY --from=build-env /opt/app-root/src/rekor_cli_darwin_amd64.gz /usr/local/bin/rekor_cli_darwin_amd64.gz
 COPY --from=build-env /opt/app-root/src/rekor_cli_linux_amd64.gz /usr/local/bin/rekor_cli_linux_amd64.gz


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini

## Summary by Sourcery

Chores:
- Set the Dockerfile labels for ‘name’ and ‘cpe’ in the rekor-cli image for Clair integration