### PR TITLE
Removing CPE labels

### DIFF
--- a/Dockerfile.backfill-redis.rh
+++ b/Dockerfile.backfill-redis.rh
@@ -29,7 +29,6 @@ LABEL io.openshift.tags="backfill-redis trusted-signer"
 LABEL summary="Provides the backfill-redis binary for a rekor server"
 LABEL com.redhat.component="backfill-redis"
 LABEL name="rhtas/rekor-backfill-redis-rhel9"
-LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 #ENTRYPOINT
 ENTRYPOINT [ "backfill-redis" ]

--- a/Dockerfile.rekor-cli.rh
+++ b/Dockerfile.rekor-cli.rh
@@ -39,7 +39,7 @@ LABEL io.k8s.display-name="Rekor-cli container image for Red Hat Trusted Signer"
 LABEL io.openshift.tags="rekor-cli trusted-signer"
 LABEL summary="Provides the rekor CLI binary for interacting with a rekor server"
 LABEL com.redhat.component="rekor-cli"
-LABEL name="rekor-cli"
+LABEL name="rhtas/rekor-cli-rhel9"
 
 COPY --from=build-env /opt/app-root/src/rekor_cli_darwin_amd64.gz /usr/local/bin/rekor_cli_darwin_amd64.gz
 COPY --from=build-env /opt/app-root/src/rekor_cli_linux_amd64.gz /usr/local/bin/rekor_cli_linux_amd64.gz

--- a/Dockerfile.rekor-server.rh
+++ b/Dockerfile.rekor-server.rh
@@ -69,7 +69,6 @@ LABEL io.k8s.display-name="Rekor-Server container image for Red Hat Trusted Sign
 LABEL io.openshift.tags="rekor-server trusted-signer"
 LABEL summary="Provides the rekor Server binary for running Rekor-Server"
 LABEL com.redhat.component="rekor-server"
-LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 LABEL name="rhtas/rekor-server-rhel9"
 
 # Retrieve the binary from the previous stage


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove CPE metadata lines from Dockerfile.backfill-redis.rh, Dockerfile.rekor-cli.rh, and Dockerfile.rekor-server.rh