### PR TITLE
Increasing Unit Test memory limit

### DIFF
--- a/.tekton/backfill-redis-pull-request.yaml
+++ b/.tekton/backfill-redis-pull-request.yaml
@@ -61,6 +61,16 @@ spec:
           cpu: "3"
           memory: 3Gi
       name: prefetch-dependencies
+  - pipelineTaskName: run-unit-test
+    stepSpecs:
+    - computeResources:
+        limits:
+          cpu: "3"
+          memory: 3Gi
+        requests:
+          cpu: "3"
+          memory: 3Gi
+      name: run-unit-test
   taskRunTemplate:
     serviceAccountName: build-pipeline-backfill-redis
   workspaces:

--- a/.tekton/backfill-redis-pull-request.yaml
+++ b/.tekton/backfill-redis-pull-request.yaml
@@ -55,20 +55,12 @@ spec:
     stepSpecs:
     - computeResources:
         limits:
-          cpu: "3"
-          memory: 3Gi
-        requests:
-          cpu: "3"
           memory: 3Gi
       name: prefetch-dependencies
   - pipelineTaskName: run-unit-test
     stepSpecs:
     - computeResources:
         limits:
-          cpu: "3"
-          memory: 3Gi
-        requests:
-          cpu: "3"
           memory: 3Gi
       name: run-tests
   taskRunTemplate:

--- a/.tekton/backfill-redis-pull-request.yaml
+++ b/.tekton/backfill-redis-pull-request.yaml
@@ -70,7 +70,7 @@ spec:
         requests:
           cpu: "3"
           memory: 3Gi
-      name: run-unit-test
+      name: run-tests
   taskRunTemplate:
     serviceAccountName: build-pipeline-backfill-redis
   workspaces:

--- a/.tekton/backfill-redis-push.yaml
+++ b/.tekton/backfill-redis-push.yaml
@@ -53,20 +53,12 @@ spec:
     stepSpecs:
     - computeResources:
         limits:
-          cpu: "3"
-          memory: 3Gi
-        requests:
-          cpu: "3"
           memory: 3Gi
       name: prefetch-dependencies
   - pipelineTaskName: run-unit-test
     stepSpecs:
     - computeResources:
         limits:
-          cpu: "3"
-          memory: 3Gi
-        requests:
-          cpu: "3"
           memory: 3Gi
       name: run-tests
   taskRunTemplate:

--- a/.tekton/backfill-redis-push.yaml
+++ b/.tekton/backfill-redis-push.yaml
@@ -59,6 +59,16 @@ spec:
           cpu: "3"
           memory: 3Gi
       name: prefetch-dependencies
+  - pipelineTaskName: run-unit-test
+    stepSpecs:
+    - computeResources:
+        limits:
+          cpu: "3"
+          memory: 3Gi
+        requests:
+          cpu: "3"
+          memory: 3Gi
+      name: run-unit-test
   taskRunTemplate:
     serviceAccountName: build-pipeline-backfill-redis
   workspaces:

--- a/.tekton/backfill-redis-push.yaml
+++ b/.tekton/backfill-redis-push.yaml
@@ -68,7 +68,7 @@ spec:
         requests:
           cpu: "3"
           memory: 3Gi
-      name: run-unit-test
+      name: run-tests
   taskRunTemplate:
     serviceAccountName: build-pipeline-backfill-redis
   workspaces:

--- a/.tekton/rekor-cli-pull-request.yaml
+++ b/.tekton/rekor-cli-pull-request.yaml
@@ -70,7 +70,7 @@ spec:
         requests:
           cpu: "3"
           memory: 3Gi
-      name: run-unit-test
+      name: run-tests
   taskRunTemplate:
     serviceAccountName: build-pipeline-rekor-cli
   workspaces:

--- a/.tekton/rekor-cli-pull-request.yaml
+++ b/.tekton/rekor-cli-pull-request.yaml
@@ -61,6 +61,16 @@ spec:
           cpu: "3"
           memory: 3Gi
       name: prefetch-dependencies
+  - pipelineTaskName: run-unit-test
+    stepSpecs:
+    - computeResources:
+        limits:
+          cpu: "3"
+          memory: 3Gi
+        requests:
+          cpu: "3"
+          memory: 3Gi
+      name: run-unit-test
   taskRunTemplate:
     serviceAccountName: build-pipeline-rekor-cli
   workspaces:

--- a/.tekton/rekor-cli-pull-request.yaml
+++ b/.tekton/rekor-cli-pull-request.yaml
@@ -55,20 +55,12 @@ spec:
     stepSpecs:
     - computeResources:
         limits:
-          cpu: "3"
-          memory: 3Gi
-        requests:
-          cpu: "3"
           memory: 3Gi
       name: prefetch-dependencies
   - pipelineTaskName: run-unit-test
     stepSpecs:
     - computeResources:
         limits:
-          cpu: "3"
-          memory: 3Gi
-        requests:
-          cpu: "3"
           memory: 3Gi
       name: run-tests
   taskRunTemplate:

--- a/.tekton/rekor-cli-push.yaml
+++ b/.tekton/rekor-cli-push.yaml
@@ -58,6 +58,16 @@ spec:
           cpu: "3"
           memory: 3Gi
       name: prefetch-dependencies
+  - pipelineTaskName: run-unit-test
+    stepSpecs:
+    - computeResources:
+        limits:
+          cpu: "3"
+          memory: 3Gi
+        requests:
+          cpu: "3"
+          memory: 3Gi
+      name: run-unit-test
   taskRunTemplate:
     serviceAccountName: build-pipeline-rekor-cli
   workspaces:

--- a/.tekton/rekor-cli-push.yaml
+++ b/.tekton/rekor-cli-push.yaml
@@ -67,7 +67,7 @@ spec:
         requests:
           cpu: "3"
           memory: 3Gi
-      name: run-unit-test
+      name: run-tests
   taskRunTemplate:
     serviceAccountName: build-pipeline-rekor-cli
   workspaces:

--- a/.tekton/rekor-cli-push.yaml
+++ b/.tekton/rekor-cli-push.yaml
@@ -52,20 +52,12 @@ spec:
     stepSpecs:
     - computeResources:
         limits:
-          cpu: "3"
-          memory: 3Gi
-        requests:
-          cpu: "3"
           memory: 3Gi
       name: prefetch-dependencies
   - pipelineTaskName: run-unit-test
     stepSpecs:
     - computeResources:
         limits:
-          cpu: "3"
-          memory: 3Gi
-        requests:
-          cpu: "3"
           memory: 3Gi
       name: run-tests
   taskRunTemplate:

--- a/.tekton/rekor-server-pull-request.yaml
+++ b/.tekton/rekor-server-pull-request.yaml
@@ -70,7 +70,7 @@ spec:
         requests:
           cpu: "3"
           memory: 3Gi
-      name: run-unit-test
+      name: run-tests
   taskRunTemplate:
     serviceAccountName: build-pipeline-rekor-server
   workspaces:

--- a/.tekton/rekor-server-pull-request.yaml
+++ b/.tekton/rekor-server-pull-request.yaml
@@ -55,20 +55,12 @@ spec:
     stepSpecs:
     - computeResources:
         limits:
-          cpu: "3"
-          memory: 3Gi
-        requests:
-          cpu: "3"
           memory: 3Gi
       name: prefetch-dependencies
   - pipelineTaskName: run-unit-test
     stepSpecs:
     - computeResources:
         limits:
-          cpu: "3"
-          memory: 3Gi
-        requests:
-          cpu: "3"
           memory: 3Gi
       name: run-tests
   taskRunTemplate:

--- a/.tekton/rekor-server-pull-request.yaml
+++ b/.tekton/rekor-server-pull-request.yaml
@@ -61,6 +61,16 @@ spec:
           cpu: "3"
           memory: 3Gi
       name: prefetch-dependencies
+  - pipelineTaskName: run-unit-test
+    stepSpecs:
+    - computeResources:
+        limits:
+          cpu: "3"
+          memory: 3Gi
+        requests:
+          cpu: "3"
+          memory: 3Gi
+      name: run-unit-test
   taskRunTemplate:
     serviceAccountName: build-pipeline-rekor-server
   workspaces:

--- a/.tekton/rekor-server-push.yaml
+++ b/.tekton/rekor-server-push.yaml
@@ -59,6 +59,16 @@ spec:
           cpu: "3"
           memory: 3Gi
       name: prefetch-dependencies
+  - pipelineTaskName: run-unit-test
+    stepSpecs:
+    - computeResources:
+        limits:
+          cpu: "3"
+          memory: 3Gi
+        requests:
+          cpu: "3"
+          memory: 3Gi
+      name: run-unit-test
   taskRunTemplate:
     serviceAccountName: build-pipeline-rekor-server
   workspaces:

--- a/.tekton/rekor-server-push.yaml
+++ b/.tekton/rekor-server-push.yaml
@@ -53,20 +53,12 @@ spec:
     stepSpecs:
     - computeResources:
         limits:
-          cpu: "3"
-          memory: 3Gi
-        requests:
-          cpu: "3"
           memory: 3Gi
       name: prefetch-dependencies
   - pipelineTaskName: run-unit-test
     stepSpecs:
     - computeResources:
         limits:
-          cpu: "3"
-          memory: 3Gi
-        requests:
-          cpu: "3"
           memory: 3Gi
       name: run-tests
   taskRunTemplate:

--- a/.tekton/rekor-server-push.yaml
+++ b/.tekton/rekor-server-push.yaml
@@ -68,7 +68,7 @@ spec:
         requests:
           cpu: "3"
           memory: 3Gi
-      name: run-unit-test
+      name: run-tests
   taskRunTemplate:
     serviceAccountName: build-pipeline-rekor-server
   workspaces:


### PR DESCRIPTION
## Summary by Sourcery

Increase resource allocation for unit tests in Tekton pipeline configurations by adding run-unit-test tasks with CPU and memory limits set to 3 cores and 3Gi across backfill-redis, rekor-cli, and rekor-server pull and push workflows.

CI:
- Add run-unit-test pipelineTask to all pull-request pipelines with CPU and memory limits set to 3 cores and 3Gi
- Mirror the same run-unit-test resource spec in all push pipelines to ensure consistent test environment