### PR TITLE
chore: update builder images

### DIFF
--- a/Dockerfile.backfill-redis.rh
+++ b/Dockerfile.backfill-redis.rh
@@ -1,6 +1,6 @@
 # Build stage
 
-FROM registry.redhat.io/ubi9/go-toolset:9.7@sha256:e8938564f866174a6d79e55dfe577c2ed184b1f53e91d782173fb69b07ce69ef AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:9.7@sha256:41b9533b2203f451a29ea2e6babd5ddcbee3a2422a1984d0e9f8172ab230cd23 AS build-env
 
 ENV GOEXPERIMENT=strictfipsruntime
 ENV CGO_ENABLED=1

--- a/Dockerfile.rekor-cli.rh
+++ b/Dockerfile.rekor-cli.rh
@@ -1,5 +1,5 @@
 #Build stage#
-FROM registry.redhat.io/ubi9/go-toolset:9.7@sha256:e8938564f866174a6d79e55dfe577c2ed184b1f53e91d782173fb69b07ce69ef AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:9.7 AS build-env
 ENV GOEXPERIMENT=strictfipsruntime
 ENV CGO_ENABLED=1
 USER root

--- a/Dockerfile.rekor-server.rh
+++ b/Dockerfile.rekor-server.rh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/ubi9/go-toolset:9.7@sha256:e8938564f866174a6d79e55dfe577c2ed184b1f53e91d782173fb69b07ce69ef AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:9.7@sha256:41b9533b2203f451a29ea2e6babd5ddcbee3a2422a1984d0e9f8172ab230cd23 AS build-env
 
 RUN mkdir -p /opt/app-root && mkdir -p /opt/app-root/src && mkdir -p /opt/app-root/src/cmd && mkdir -p /opt/app-root/src/pkg && git config --global --add safe.directory /opt/app-root/src
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update go-toolset builder image SHA256 digest in two Dockerfiles

- Remove pinned digest from rekor-cli Dockerfile for flexibility

- Maintain consistency across Red Hat UBI9 go-toolset base images


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dockerfile.backfill-redis.rh"] -- "Update SHA256 digest" --> B["New go-toolset image"]
  C["Dockerfile.rekor-server.rh"] -- "Update SHA256 digest" --> B
  D["Dockerfile.rekor-cli.rh"] -- "Remove digest pin" --> E["Unpinned go-toolset:9.7"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.backfill-redis.rh</strong><dd><code>Update go-toolset image digest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.backfill-redis.rh

<ul><li>Update go-toolset base image SHA256 digest to newer version<br> <li> Change from <br><code>e8938564f866174a6d79e55dfe577c2ed184b1f53e91d782173fb69b07ce69ef</code> to <br><code>41b9533b2203f451a29ea2e6babd5ddcbee3a2422a1984d0e9f8172ab230cd23</code></ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/rekor/pull/549/files#diff-91c1d79aa2cf154e3ef8f45ea299df9db124b1035c8a0db5c32694c00172cd69">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.rekor-cli.rh</strong><dd><code>Remove pinned digest from go-toolset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.rekor-cli.rh

<ul><li>Remove pinned SHA256 digest from go-toolset base image reference<br> <li> Simplify image specification to use tag-only reference <br><code>registry.redhat.io/ubi9/go-toolset:9.7</code></ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/rekor/pull/549/files#diff-9d97c97f7b8d304b1a64d5339ea3429214c8e3501f5ed2d335fcbad8a77dc8d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.rekor-server.rh</strong><dd><code>Update go-toolset image digest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.rekor-server.rh

<ul><li>Update go-toolset base image SHA256 digest to newer version<br> <li> Change from <br><code>e8938564f866174a6d79e55dfe577c2ed184b1f53e91d782173fb69b07ce69ef</code> to <br><code>41b9533b2203f451a29ea2e6babd5ddcbee3a2422a1984d0e9f8172ab230cd23</code></ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/rekor/pull/549/files#diff-cd79de98e3a7be52bd0fe4a60f4132c5b33b403c6a0b3f82ae3fa9b1519e24eb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

