### PR TITLE
Add sync-upstream workflow

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -1,0 +1,32 @@
+name: Sync Upstream
+on:
+  schedule:
+    - cron: '17 8 * * 1'  # Weekly Monday 8:17 UTC
+  workflow_dispatch:
+    inputs:
+      upstream_ref:
+        description: 'Upstream ref to merge (leave empty for latest release)'
+        required: false
+        default: ''
+
+jobs:
+  generate-token:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+
+  sync:
+    needs: generate-token
+    uses: securesign/actions/.github/workflows/sync-upstream.yaml@main
+    with:
+      upstream_repo: https://github.com/sigstore/rekor
+      upstream_ref: ${{ inputs.upstream_ref || '' }}
+      target_branch: main
+    secrets:
+      token: ${{ needs.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Adds caller workflow for automated upstream sync with sigstore/rekor
- Uses the shared reusable workflow from securesign/actions ([PR #13](https://github.com/securesign/actions/pull/13))
- Runs weekly (Monday 8:17 UTC) and supports manual trigger via `workflow_dispatch`
- Uses GitHub App token for authentication so PRs trigger CI automatically

## Dependencies
- securesign/actions PR #13 must be merged first

## Test plan
- [ ] Merge securesign/actions PR #13
- [ ] Configure GitHub App (`SYNC_APP_ID` / `SYNC_APP_PRIVATE_KEY`) on the org
- [ ] Install the app on securesign/rekor
- [ ] Trigger manually via Actions → Sync Upstream → Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)