### PR TITLE
Fix: pass app credentials directly to sync-upstream workflow

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -10,23 +10,12 @@ on:
         default: ''
 
 jobs:
-  generate-token:
-    runs-on: ubuntu-latest
-    outputs:
-      token: ${{ steps.app-token.outputs.token }}
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-
   sync:
-    needs: generate-token
     uses: securesign/actions/.github/workflows/sync-upstream.yaml@main
     with:
       upstream_repo: https://github.com/sigstore/rekor
       upstream_ref: ${{ inputs.upstream_ref || '' }}
       target_branch: main
+      app_id: ${{ vars.SYNC_APP_ID }}
     secrets:
-      token: ${{ needs.generate-token.outputs.token }}
+      app_private_key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Passes `app_id` and `app_private_key` directly to the reusable workflow instead of generating a token in a separate job
- Simplifies the caller from 2 jobs to 1

## Dependencies
- securesign/actions PR #14 must be merged first

## Test plan
- [ ] Merge securesign/actions PR #14
- [ ] Merge this PR
- [ ] Trigger sync-upstream manually via Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)