### PR TITLE
Fix GitHub App token scope for sync-upstream

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           app-id: ${{ vars.SYNC_APP_ID }}
           private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - uses: securesign/actions/sync-upstream@main
         with:


### PR DESCRIPTION
## Summary
Add `owner: ${{ github.repository_owner }}` to `actions/create-github-app-token` step.

## Root cause
Without `owner`, the token is scoped to the current repository only. The composite action uses `gh pr create --repo securesign/rekor` (explicit repo targeting to avoid creating PRs against the upstream parent). This explicit `--repo` flag requires the token to be scoped to the org installation, not just the current repo.

## Test plan
- [ ] Merge and trigger sync-upstream manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)