### PR TITLE
Rework cli-stack: move cross-compilation out of component

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -27,7 +27,11 @@ CLI_LDFLAGS=$(REKOR_LDFLAGS)
 SERVER_LDFLAGS=$(REKOR_LDFLAGS)
 FIPS_MODULE ?= latest
 
-.PHONY: 
+.PHONY: rekor-cli-linux
+rekor-cli-linux: ## Build native Linux binary (FIPS, CGO)
+	env CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOFLAGS="-buildvcs=false" go build -o rekor_cli_linux -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
+
+.PHONY:
 cross-platform: rekor-cli-darwin-arm64 rekor-cli-darwin-amd64 rekor-cli-windows ## Build all distributable (cross-platform) binaries
 
 .PHONY:	rekor-cli-darwin-arm64

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -1,53 +1,69 @@
-FROM --platform=linux/amd64   quay.io/securesign/rekor-cli@sha256:4f297ebc1917d68bd93903687b5ff0c0740801594a8ed234d676512f367e02a7 AS build-amd64
-FROM --platform=linux/arm64   quay.io/securesign/rekor-cli@sha256:73a707e13c90cc5388f2d0cf04cf4e650e951b62d1f7f5d688ac33fbc7f5cf6e AS build-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/rekor-cli@sha256:8bf706967755e6489dcc8e4e71717eef4452950c8b5184bc06336c8cc67812bf AS build-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/rekor-cli@sha256:44b2ded738016fae222db9319eb843612a2d67011b103ea82b9ef6b3e57ca198 AS build-s390x
+FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS build-cross-platform
+ENV APP_ROOT=/opt/app-root \
+    GOPATH=/opt/app-root \
+    GOFLAGS="-buildvcs=false"
 
-FROM registry.redhat.io/ubi9/go-toolset:9.7-1774499506@sha256:2830e4bd1c394ed506c00a9abbb4d00445e2e72e8ef4e3cd51e0da0db66dee12 AS packager
+USER root
+
+RUN mkdir -p /opt/app-root && mkdir -p /opt/app-root/src && git config --global --add safe.directory /opt/app-root/src
+
+WORKDIR $APP_ROOT/src
+
+COPY . .
+
+WORKDIR $APP_ROOT/src/hack/tools
+RUN go mod vendor
+
+WORKDIR $APP_ROOT/src
+RUN git update-index --assume-unchanged Dockerfile.rekor-cli.rh && \
+    git update-index --assume-unchanged Dockerfile.cli-stack.rh && \
+    go mod vendor && \
+    make Makefile.swagger && \
+    make -f Build.mak cross-platform
+
+FROM --platform=linux/amd64   quay.io/securesign/rekor-cli@sha256:98bdae30cd639957f2dc143e2888fcdfaf406ea2a325db8de7d8b3692c8ed9f6 AS build-amd64
+FROM --platform=linux/arm64   quay.io/securesign/rekor-cli@sha256:98bdae30cd639957f2dc143e2888fcdfaf406ea2a325db8de7d8b3692c8ed9f6 AS build-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/rekor-cli@sha256:98bdae30cd639957f2dc143e2888fcdfaf406ea2a325db8de7d8b3692c8ed9f6 AS build-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/rekor-cli@sha256:98bdae30cd639957f2dc143e2888fcdfaf406ea2a325db8de7d8b3692c8ed9f6 AS build-s390x
+
+FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS packager
 USER root
 RUN mkdir -p /binaries
 
-# Native Linux binaries from each arch variant
-COPY --from=build-amd64 /usr/local/bin/rekor_cli_linux.gz /tmp/rekor_cli_linux.gz
-RUN gzip -d /tmp/rekor_cli_linux.gz && \
-    tar -czf /binaries/rekor_cli_linux_amd64.tar.gz -C /tmp rekor_cli_linux && \
+# rekor-cli: Native Linux binaries from each arch variant
+COPY --from=build-amd64 /usr/local/bin/rekor_cli_linux /tmp/rekor_cli_linux
+RUN tar -czf /binaries/rekor_cli_linux_amd64.tar.gz -C /tmp rekor_cli_linux && \
     rm /tmp/rekor_cli_linux
 
-COPY --from=build-arm64 /usr/local/bin/rekor_cli_linux.gz /tmp/rekor_cli_linux.gz
-RUN gzip -d /tmp/rekor_cli_linux.gz && \
-    tar -czf /binaries/rekor_cli_linux_arm64.tar.gz -C /tmp rekor_cli_linux && \
+COPY --from=build-arm64 /usr/local/bin/rekor_cli_linux /tmp/rekor_cli_linux
+RUN tar -czf /binaries/rekor_cli_linux_arm64.tar.gz -C /tmp rekor_cli_linux && \
     rm /tmp/rekor_cli_linux
 
-COPY --from=build-ppc64le /usr/local/bin/rekor_cli_linux.gz /tmp/rekor_cli_linux.gz
-RUN gzip -d /tmp/rekor_cli_linux.gz && \
-    tar -czf /binaries/rekor_cli_linux_ppc64le.tar.gz -C /tmp rekor_cli_linux && \
+COPY --from=build-ppc64le /usr/local/bin/rekor_cli_linux /tmp/rekor_cli_linux
+RUN tar -czf /binaries/rekor_cli_linux_ppc64le.tar.gz -C /tmp rekor_cli_linux && \
     rm /tmp/rekor_cli_linux
 
-COPY --from=build-s390x /usr/local/bin/rekor_cli_linux.gz /tmp/rekor_cli_linux.gz
-RUN gzip -d /tmp/rekor_cli_linux.gz && \
-    tar -czf /binaries/rekor_cli_linux_s390x.tar.gz -C /tmp rekor_cli_linux && \
+COPY --from=build-s390x /usr/local/bin/rekor_cli_linux /tmp/rekor_cli_linux
+RUN tar -czf /binaries/rekor_cli_linux_s390x.tar.gz -C /tmp rekor_cli_linux && \
     rm /tmp/rekor_cli_linux
 
-# Darwin amd64
-COPY --from=build-amd64 /usr/local/bin/rekor_cli_darwin_amd64.gz /tmp/rekor_cli_darwin_amd64.gz
-RUN gzip -d /tmp/rekor_cli_darwin_amd64.gz && \
-    tar -czf /binaries/rekor_cli_darwin_amd64.tar.gz -C /tmp rekor_cli_darwin_amd64 && \
+# rekor-cli: Cross-compiled binaries
+COPY --from=build-cross-platform /opt/app-root/src/rekor_cli_darwin_amd64 /tmp/rekor_cli_darwin_amd64
+RUN tar -czf /binaries/rekor_cli_darwin_amd64.tar.gz -C /tmp rekor_cli_darwin_amd64 && \
     rm /tmp/rekor_cli_darwin_amd64
 
-# Darwin arm64
-COPY --from=build-amd64 /usr/local/bin/rekor_cli_darwin_arm64.gz /tmp/rekor_cli_darwin_arm64.gz
-RUN gzip -d /tmp/rekor_cli_darwin_arm64.gz && \
-    tar -czf /binaries/rekor_cli_darwin_arm64.tar.gz -C /tmp rekor_cli_darwin_arm64 && \
+COPY --from=build-cross-platform /opt/app-root/src/rekor_cli_darwin_arm64 /tmp/rekor_cli_darwin_arm64
+RUN tar -czf /binaries/rekor_cli_darwin_arm64.tar.gz -C /tmp rekor_cli_darwin_arm64 && \
     rm /tmp/rekor_cli_darwin_arm64
 
-# Windows amd64
-COPY --from=build-amd64 /usr/local/bin/rekor_cli_windows_amd64.exe.gz /tmp/rekor_cli_windows_amd64.exe.gz
-RUN gzip -d /tmp/rekor_cli_windows_amd64.exe.gz && \
-    tar -czf /binaries/rekor_cli_windows_amd64.tar.gz -C /tmp rekor_cli_windows_amd64.exe && \
+COPY --from=build-cross-platform /opt/app-root/src/rekor_cli_windows_amd64.exe /tmp/rekor_cli_windows_amd64.exe
+RUN tar -czf /binaries/rekor_cli_windows_amd64.tar.gz -C /tmp rekor_cli_windows_amd64.exe && \
     rm /tmp/rekor_cli_windows_amd64.exe
 
+RUN chmod -R a+rX /binaries
+
 # Final minimal image with all binaries
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
+FROM registry.redhat.io/ubi9/ubi-micro:9.8@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa
 
 LABEL description="Flat image containing rekor-cli binaries for all platforms and architectures"
 LABEL io.k8s.description="Flat image containing rekor-cli binaries for all platforms and architectures"
@@ -56,10 +72,9 @@ LABEL io.k8s.display-name="Rekor CLI stack image for Red Hat Trusted Artifact Si
 LABEL io.openshift.tags="rekor-cli trusted-artifact-signer cli-stack"
 LABEL summary="Provides all rekor-cli binaries as tar.gz archives for CDN distribution."
 LABEL com.redhat.component="rekor-cli-stack"
+LABEL name="rhtas/rekor-cli-stack"
 
 COPY --from=packager /binaries/ /binaries/
 COPY --from=build-amd64 /licenses/ /licenses/
-
-RUN chown -R root:0 /binaries && chmod -R g+r /binaries
 
 USER 65532:65532

--- a/Dockerfile.rekor-cli.rh
+++ b/Dockerfile.rekor-cli.rh
@@ -1,10 +1,7 @@
 #Build stage#
 FROM registry.redhat.io/ubi9/go-toolset:9.7-1774499506@sha256:2830e4bd1c394ed506c00a9abbb4d00445e2e72e8ef4e3cd51e0da0db66dee12 AS build-env
 ENV APP_ROOT=/opt/app-root \
-    GOPATH=/opt/app-root \
-    CGO_ENABLED=1 \
-    GOFLAGS="-buildvcs=false" \
-    GOEXPERIMENT=strictfipsruntime
+    GOPATH=/opt/app-root
 
 USER root
 
@@ -18,25 +15,10 @@ WORKDIR /opt/app-root/src/hack/tools
 RUN go mod vendor
 
 WORKDIR /opt/app-root/src
-RUN set -euo pipefail; \
-    git update-index --assume-unchanged Dockerfile.rekor-cli.rh; \
-    GIT_VERSION="$(git describe --tags --always --dirty)"; \
-    GIT_HASH="$(git rev-parse HEAD)"; \
-    GIT_TREESTATE=clean \
-    BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"; \
-    REKOR_LDFLAGS="-X sigs.k8s.io/release-utils/version.gitVersion=${GIT_VERSION} \
-                   -X sigs.k8s.io/release-utils/version.gitCommit=${GIT_HASH} \
-                   -X sigs.k8s.io/release-utils/version.gitTreeState=${GIT_TREESTATE} \
-                   -X sigs.k8s.io/release-utils/version.buildDate=${BUILD_DATE}"; \
-    CLI_LDFLAGS="${REKOR_LDFLAGS}"; \
-    go mod vendor; \
-    make Makefile.swagger; \
-    go build -o rekor_cli_linux -trimpath -ldflags "${CLI_LDFLAGS} -w -s" ./cmd/rekor-cli; \
-    gzip -k rekor_cli_linux; \
-    make -f Build.mak cross-platform; \
-    gzip -k rekor_cli_darwin_amd64; \
-    gzip -k rekor_cli_windows_amd64.exe; \
-    gzip -k rekor_cli_darwin_arm64; \
+RUN git update-index --assume-unchanged Dockerfile.rekor-cli.rh && \
+    go mod vendor && \
+    make Makefile.swagger && \
+    make -f Build.mak rekor-cli-linux && \
     git update-index --no-assume-unchanged Dockerfile.rekor-cli.rh
 
 #Install stage
@@ -50,11 +32,7 @@ LABEL summary="Provides the rekor CLI binary for interacting with a rekor server
 LABEL com.redhat.component="rekor-cli"
 LABEL name="rhtas/rekor-cli-rhel9"
 
-COPY --from=build-env /opt/app-root/src/rekor_cli_linux.gz /usr/local/bin/rekor_cli_linux.gz
 COPY --from=build-env /opt/app-root/src/rekor_cli_linux /usr/local/bin/rekor_cli_linux
-COPY --from=build-env /opt/app-root/src/rekor_cli_darwin_amd64.gz /usr/local/bin/rekor_cli_darwin_amd64.gz
-COPY --from=build-env /opt/app-root/src/rekor_cli_darwin_arm64.gz /usr/local/bin/rekor_cli_darwin_arm64.gz
-COPY --from=build-env /opt/app-root/src/rekor_cli_windows_amd64.exe.gz /usr/local/bin/rekor_cli_windows_amd64.exe.gz
 
 COPY LICENSE /licenses/license.txt
 WORKDIR /opt/app-root/src/home


### PR DESCRIPTION
## Summary
- **Component Dockerfile** (`Dockerfile.rekor-cli.rh`): Remove cross-compilation (`make -f Build.mak cross-platform`), all `gzip` steps, and all `.gz` COPY lines. Output is now a single native `rekor_cli_linux` binary.
- **CLI-stack Dockerfile** (`Dockerfile.cli-stack.rh`): Add `build-cross-platform` stage (go-toolset:9.8, CGO_ENABLED=0, GOFIPS140=v1.0.0). Use single manifest digest for all 4 arch FROM lines. Copy native binaries directly (no `gzip -d`). Switch final image to `ubi-micro:9.8`. Use `chmod -R a+rX` in packager.

Follows the pattern established in [securesign/trillian#708](https://github.com/securesign/trillian/pull/708).

> **Note**: `REPLACE_WITH_MANIFEST_DIGEST` in cli-stack needs to be updated with the actual manifest digest after the component image is rebuilt.

## Test plan
- [ ] Component image (`rekor-cli`) build succeeds on Konflux
- [ ] Update manifest digest in cli-stack after component rebuild
- [ ] CLI-stack image build succeeds
- [ ] Enterprise Contract passes
- [ ] Built cli-stack image contains all expected tar.gz archives

🤖 Generated with [Claude Code](https://claude.com/claude-code)