### PR TITLE
chore: enable native go FIPS, create FIPS Safe build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,12 @@ jobs:
           check-latest: true
           cache: false
 
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - name: deps
         run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,6 +58,12 @@ jobs:
         check-latest: true
         cache: false
 
+    - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+      run: |
+        go mod edit -dropgodebug=fips140
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        git update-index --assume-unchanged go.mod
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,12 @@ jobs:
           go-version: ${{ env.GOVERSION }}
           cache: false
 
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - name: Build
         run: make -C $GITHUB_WORKSPACE all
       - name: Fuzz-Build
@@ -69,6 +75,12 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
           cache: false
+
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
 
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
@@ -100,6 +112,13 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
           cache: false
+
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - name: install gocovmerge
         run: make gocovmerge
 
@@ -152,6 +171,13 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
           cache: false
+
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - name: Install backfill test dependencies
         run: |
           go install ./cmd/rekor-cli
@@ -202,6 +228,12 @@ jobs:
           go-version: ${{ env.GOVERSION }}
           cache: false
 
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - name: Sharding Test
         run: ./tests/sharding-e2e-test.sh
       - name: Upload logs if they exist
@@ -220,6 +252,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - name: Docker Build
         run: docker compose build
       - name: Extract version of Go to use
@@ -247,6 +286,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - name: Docker Build
         run: docker compose build
       - name: Extract version of Go to use
@@ -293,6 +339,15 @@ jobs:
           go-version: ${{ env.GOVERSION }}
           check-latest: true
           cache: false
+
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config user.email "ci@rhtas.dev"
+          git config user.name "CI"
+          git add go.mod
+          git commit -m "temp: drop fips140 godebug for CI"
 
       - name: Run test harness
         run: ./tests/rekor-harness.sh

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -33,14 +33,14 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/sigstore/cosign/cosign:v3.0.4-dev@sha256:782e916a04d4b879fdadb94366f9b58fdf13b6b2e24635a9c9b6cbf57799df02
+      image: ghcr.io/sigstore/cosign/cosign:v3.0.6-dev@sha256:fd2e25faec7ea4c47bfbe6f50f00ff0e465fcea1f6d121eed7491b79278b19f7
 
     steps:
       - name: Check Signature
         run: |
-          cosign verify ghcr.io/gythialy/golang-cross:v1.25.7-0@sha256:a0387993e09553d95e73e0a0d6e1fc9b4989f5b5eea9759e0a6bbfba464840d2 \
+          cosign verify ghcr.io/gythialy/golang-cross:v1.26.3-0@sha256:9f7a53d7205e2f1f2742d624ff0b6e1531e8c22863dfb24ca966be5efbdee48b \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.25.7-0"
+          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.26.3-0"
         env:
           TUF_ROOT: /tmp
 
@@ -54,7 +54,7 @@ jobs:
       contents: read
 
     container:
-      image: ghcr.io/gythialy/golang-cross:v1.25.7-0@sha256:a0387993e09553d95e73e0a0d6e1fc9b4989f5b5eea9759e0a6bbfba464840d2
+      image: ghcr.io/gythialy/golang-cross:v1.26.3-0@sha256:9f7a53d7205e2f1f2742d624ff0b6e1531e8c22863dfb24ca966be5efbdee48b
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -93,6 +93,12 @@ jobs:
           rm -rf /host_opt/ghc || true
       - name: check disk space
         run: df -h
+
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
 
       - name: goreleaser snapshot
         run: make snapshot

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -40,6 +40,12 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
 
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
+
       - name: Install addlicense
         run: go install github.com/google/addlicense@v1.0.0
 
@@ -63,6 +69,12 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GOVERSION }}
+
+      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
+        run: |
+          go mod edit -dropgodebug=fips140
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git update-index --assume-unchanged go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/Build.mak
+++ b/Build.mak
@@ -25,7 +25,7 @@ REKOR_LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_VERSION) \
 
 CLI_LDFLAGS=$(REKOR_LDFLAGS)
 SERVER_LDFLAGS=$(REKOR_LDFLAGS)
-FIPS_MODULE ?= latest
+FIPS_MODULE ?= v1.0.0
 
 .PHONY: rekor-cli-linux
 rekor-cli-linux: ## Build native Linux binary (FIPS, CGO)
@@ -36,12 +36,12 @@ cross-platform: rekor-cli-darwin-arm64 rekor-cli-darwin-amd64 rekor-cli-windows 
 
 .PHONY:	rekor-cli-darwin-arm64
 rekor-cli-darwin-arm64: $(SRCS)## Build for mac M1
-	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=arm64 go build -v -o rekor_cli_darwin_arm64 -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=arm64 go build -v -o rekor_cli_darwin_arm64 -tags=no_openssl -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
 
 .PHONY: rekor-cli-darwin-amd64
 rekor-cli-darwin-amd64:  $(SRCS)## Build for Darwin (macOS)
-	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=amd64 go build -o rekor_cli_darwin_amd64 -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=darwin GOARCH=amd64 go build -o rekor_cli_darwin_amd64 -tags=no_openssl -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
 
 .PHONY: rekor-cli-windows
 rekor-cli-windows: $(SRCS) ## Build for Windows
-	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=windows GOARCH=amd64 go build -o rekor_cli_windows_amd64.exe -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOOS=windows GOARCH=amd64 go build -o rekor_cli_windows_amd64.exe -tags=no_openssl -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli

--- a/Dockerfile.backfill-redis.rh
+++ b/Dockerfile.backfill-redis.rh
@@ -1,9 +1,10 @@
 # Build stage
 
-FROM registry.redhat.io/ubi9/go-toolset:9.7-1774499506@sha256:2830e4bd1c394ed506c00a9abbb4d00445e2e72e8ef4e3cd51e0da0db66dee12 AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS build-env
 
-ENV GOEXPERIMENT=strictfipsruntime
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
+ENV GOFLAGS="-tags=no_openssl"
+ENV GOFIPS140=v1.0.0
 
 USER root
 RUN mkdir -p /opt/app-root && mkdir -p /opt/app-root/src && git config --global --add safe.directory /opt/app-root/src

--- a/Dockerfile.rekor-cli.rh
+++ b/Dockerfile.rekor-cli.rh
@@ -1,7 +1,10 @@
 #Build stage#
-FROM registry.redhat.io/ubi9/go-toolset:9.7-1774499506@sha256:2830e4bd1c394ed506c00a9abbb4d00445e2e72e8ef4e3cd51e0da0db66dee12 AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS build-env
 ENV APP_ROOT=/opt/app-root \
-    GOPATH=/opt/app-root
+    GOPATH=/opt/app-root \
+    CGO_ENABLED=0 \
+    GOFLAGS="-buildvcs=false -tags=no_openssl" \
+    GOFIPS140=v1.0.0
 
 USER root
 

--- a/Dockerfile.rekor-server.rh
+++ b/Dockerfile.rekor-server.rh
@@ -13,14 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/ubi9/go-toolset:9.7-1774499506@sha256:2830e4bd1c394ed506c00a9abbb4d00445e2e72e8ef4e3cd51e0da0db66dee12 AS build-env
+FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS build-env
 
 RUN mkdir -p /opt/app-root && mkdir -p /opt/app-root/src && mkdir -p /opt/app-root/src/cmd && mkdir -p /opt/app-root/src/pkg && git config --global --add safe.directory /opt/app-root/src
 
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
-ENV GOEXPERIMENT=strictfipsruntime
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
+ENV GOFLAGS="-tags=no_openssl"
+ENV GOFIPS140=v1.0.0
 
 WORKDIR $APP_ROOT/src/
 ADD go.mod go.sum $APP_ROOT/src/

--- a/cmd/rekor-cli/app/log_info.go
+++ b/cmd/rekor-cli/app/log_info.go
@@ -26,7 +26,7 @@ import (
 	"github.com/go-openapi/swag/conv"
 	rclient "github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/models"
-
+	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
 	"github.com/sigstore/rekor/pkg/verify"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -181,6 +181,13 @@ func loadVerifier(ctx context.Context, rekorClient *rclient.Rekor, treeID string
 	if err != nil {
 		return nil, err
 	}
+
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if err := pkitypes.ValidatePublicKey(pub); err != nil {
+		return nil, err
+	}
+	// ========================================
 
 	return signature.LoadVerifier(pub, crypto.SHA256)
 }

--- a/cmd/rekor-cli/app/search.go
+++ b/cmd/rekor-cli/app/search.go
@@ -16,6 +16,7 @@
 package app
 
 import (
+	"crypto/fips140"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -148,20 +149,33 @@ var searchCmd = &cobra.Command{
 		if publicKeyStr != "" {
 			params.Query.PublicKey = &models.SearchIndexPublicKey{}
 			pkiFormat := viper.GetString("pki-format")
+			// RHTAS FIPS - DO NOT REMOVE
+			// ========================================
+			// PGP, SSH, and Minisign use non-FIPS-validated crypto modules.
 			switch pkiFormat {
 			case "pgp":
+				if fips140.Enabled() {
+					return nil, fmt.Errorf("pgp is not supported in FIPS mode")
+				}
 				params.Query.PublicKey.Format = conv.Pointer(models.SearchIndexPublicKeyFormatPgp)
 			case "minisign":
+				if fips140.Enabled() {
+					return nil, fmt.Errorf("minisign is not supported in FIPS mode")
+				}
 				params.Query.PublicKey.Format = conv.Pointer(models.SearchIndexPublicKeyFormatMinisign)
 			case "x509":
 				params.Query.PublicKey.Format = conv.Pointer(models.SearchIndexPublicKeyFormatX509)
 			case "ssh":
+				if fips140.Enabled() {
+					return nil, fmt.Errorf("ssh is not supported in FIPS mode")
+				}
 				params.Query.PublicKey.Format = conv.Pointer(models.SearchIndexPublicKeyFormatSSH)
 			case "tuf":
 				params.Query.PublicKey.Format = conv.Pointer(models.SearchIndexPublicKeyFormatTUF)
 			default:
 				return nil, fmt.Errorf("unknown pki-format %v", pkiFormat)
 			}
+			// ========================================
 
 			splitPubKeyString := strings.Split(publicKeyStr, ",")
 			if len(splitPubKeyString) == 1 {

--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -16,6 +16,7 @@
 package app
 
 import (
+	"crypto/fips140"
 	"flag"
 	"fmt"
 	"net/http"
@@ -108,17 +109,25 @@ var serveCmd = &cobra.Command{
 		// which registers each type's constructor in types.TypeMap.
 		entryTypeMap := map[string][]string{
 			rekord.KIND:       {rekord_v001.APIVERSION},
-			rpm.KIND:          {rpm_v001.APIVERSION},
 			jar.KIND:          {jar_v001.APIVERSION},
 			intoto.KIND:       {intoto_v001.APIVERSION, intoto_v002.APIVERSION},
 			cose.KIND:         {cose_v001.APIVERSION},
 			rfc3161.KIND:      {rfc3161_v001.APIVERSION},
-			alpine.KIND:       {alpine_v001.APIVERSION},
-			helm.KIND:         {helm_v001.APIVERSION},
 			tuf.KIND:          {tuf_v001.APIVERSION},
 			hashedrekord.KIND: {hashedrekord_v001.APIVERSION},
 			dsse.KIND:         {dsse_v001.APIVERSION},
 		}
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		// Alpine uses non-FIPS signature verification.
+		// Helm and RPM depend exclusively on PGP (golang.org/x/crypto/openpgp),
+		// which is not a FIPS-validated module.
+		if !fips140.Enabled() {
+			entryTypeMap[alpine.KIND] = []string{alpine_v001.APIVERSION}
+			entryTypeMap[helm.KIND] = []string{helm_v001.APIVERSION}
+			entryTypeMap[rpm.KIND] = []string{rpm_v001.APIVERSION}
+		}
+		// ========================================
 
 		// Using --enabled_entry_types, restrict which kinds the server will
 		// accept for new submissions. By default, support every type compiled

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/sigstore/rekor
 
-go 1.25.7
+go 1.26.3
+
+godebug fips140=auto
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -17,6 +17,7 @@ package api
 
 import (
 	"context"
+	"crypto/fips140"
 	"crypto/tls"
 	"fmt"
 	"slices"
@@ -67,6 +68,24 @@ var AllowedClientSigningAlgorithms = []v1.PublicKeyDetails{
 	v1.PublicKeyDetails_PKIX_ED25519_PH,
 }
 var DefaultClientSigningAlgorithms = AllowedClientSigningAlgorithms
+
+// RHTAS FIPS - DO NOT REMOVE
+// ========================================
+func init() {
+	if fips140.Enabled() {
+		filtered := make([]v1.PublicKeyDetails, 0, len(AllowedClientSigningAlgorithms))
+		for _, a := range AllowedClientSigningAlgorithms {
+			if a == v1.PublicKeyDetails_PKIX_ED25519 || a == v1.PublicKeyDetails_PKIX_ED25519_PH {
+				continue
+			}
+			filtered = append(filtered, a)
+		}
+		AllowedClientSigningAlgorithms = filtered
+		DefaultClientSigningAlgorithms = AllowedClientSigningAlgorithms
+	}
+}
+
+// ========================================
 
 func NewAPI(treeID int64) (*API, error) {
 	ctx := context.Background()
@@ -128,6 +147,12 @@ func NewAPI(treeID int64) (*API, error) {
 			if err != nil {
 				return nil, fmt.Errorf("parsing signature algorithm flag: %w", err)
 			}
+			// RHTAS FIPS - DO NOT REMOVE
+			// ========================================
+			if fips140.Enabled() && !slices.Contains(AllowedClientSigningAlgorithms, algorithm) {
+				return nil, fmt.Errorf("algorithm %q is not allowed in FIPS mode", a)
+			}
+			// ========================================
 			algorithms = append(algorithms, algorithm)
 		}
 	}

--- a/pkg/pki/factory.go
+++ b/pkg/pki/factory.go
@@ -16,6 +16,7 @@
 package pki
 
 import (
+	"crypto/fips140"
 	"fmt"
 	"io"
 
@@ -58,30 +59,6 @@ var artifactFactoryMap map[Format]pkiImpl
 
 func init() {
 	artifactFactoryMap = map[Format]pkiImpl{
-		PGP: {
-			newPubKey: func(r io.Reader) (PublicKey, error) {
-				return pgp.NewPublicKey(r)
-			},
-			newSignature: func(r io.Reader) (Signature, error) {
-				return pgp.NewSignature(r)
-			},
-		},
-		Minisign: {
-			newPubKey: func(r io.Reader) (PublicKey, error) {
-				return minisign.NewPublicKey(r)
-			},
-			newSignature: func(r io.Reader) (Signature, error) {
-				return minisign.NewSignature(r)
-			},
-		},
-		SSH: {
-			newPubKey: func(r io.Reader) (PublicKey, error) {
-				return ssh.NewPublicKey(r)
-			},
-			newSignature: func(r io.Reader) (Signature, error) {
-				return ssh.NewSignature(r)
-			},
-		},
 		X509: {
 			newPubKey: func(r io.Reader) (PublicKey, error) {
 				return x509.NewPublicKey(r)
@@ -107,6 +84,38 @@ func init() {
 			},
 		},
 	}
+
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	// PGP (golang.org/x/crypto/openpgp), SSH (golang.org/x/crypto/ssh), and
+	// Minisign (ed25519-only) use non-FIPS-validated crypto modules.
+	if !fips140.Enabled() {
+		artifactFactoryMap[PGP] = pkiImpl{
+			newPubKey: func(r io.Reader) (PublicKey, error) {
+				return pgp.NewPublicKey(r)
+			},
+			newSignature: func(r io.Reader) (Signature, error) {
+				return pgp.NewSignature(r)
+			},
+		}
+		artifactFactoryMap[SSH] = pkiImpl{
+			newPubKey: func(r io.Reader) (PublicKey, error) {
+				return ssh.NewPublicKey(r)
+			},
+			newSignature: func(r io.Reader) (Signature, error) {
+				return ssh.NewSignature(r)
+			},
+		}
+		artifactFactoryMap[Minisign] = pkiImpl{
+			newPubKey: func(r io.Reader) (PublicKey, error) {
+				return minisign.NewPublicKey(r)
+			},
+			newSignature: func(r io.Reader) (Signature, error) {
+				return minisign.NewSignature(r)
+			},
+		}
+	}
+	// ========================================
 }
 
 func SupportedFormats() []string {

--- a/pkg/pki/pkcs7/pkcs7.go
+++ b/pkg/pki/pkcs7/pkcs7.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/sassoftware/relic/lib/pkcs7"
 	"github.com/sigstore/rekor/pkg/pki/identity"
+	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	sigsig "github.com/sigstore/sigstore/pkg/signature"
 )
@@ -171,7 +172,13 @@ func NewPublicKey(r io.Reader) (*PublicKey, error) {
 		return nil, err
 	}
 	for _, cert := range certs {
-		return &PublicKey{key: cert.PublicKey, certs: certs, rawCert: cert.Raw}, nil
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		if err := pkitypes.ValidatePublicKey(cert.PublicKey); err != nil {
+			return nil, err
+		}
+		// ========================================
+		return &PublicKey{key: cert.PublicKey, certs: certs, rawCert: cert.Raw}, nil //nolint:staticcheck // SA4004 pre-existing pattern: grabs first cert
 	}
 	return nil, errors.New("unable to extract public key from certificate inside PKCS7 bundle")
 }

--- a/pkg/pki/pkitypes/types.go
+++ b/pkg/pki/pkitypes/types.go
@@ -16,11 +16,44 @@
 package pki
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/fips140"
+	"crypto/rsa"
+	"errors"
+	"fmt"
 	"io"
 
 	"github.com/sigstore/rekor/pkg/pki/identity"
 	sigsig "github.com/sigstore/sigstore/pkg/signature"
 )
+
+// RHTAS FIPS - DO NOT REMOVE
+// ========================================
+// ValidatePublicKey checks whether a crypto.PublicKey uses a FIPS-approved
+// algorithm. Returns nil when FIPS mode is disabled or when the key is approved.
+// Approved: RSA (>= 2048-bit), ECDSA. Rejected: Ed25519, DSA, all others.
+func ValidatePublicKey(pub crypto.PublicKey) error {
+	if !fips140.Enabled() {
+		return nil
+	}
+	switch k := pub.(type) {
+	case *rsa.PublicKey:
+		if k.N.BitLen() < 2048 {
+			return fmt.Errorf("RSA key size %d below FIPS minimum 2048", k.N.BitLen())
+		}
+		return nil
+	case *ecdsa.PublicKey:
+		return nil
+	case ed25519.PublicKey:
+		return errors.New("ed25519 is not supported in FIPS mode")
+	default:
+		return fmt.Errorf("unsupported key type %T in FIPS mode", pub)
+	}
+}
+
+// ========================================
 
 // PublicKey Generic object representing a public key (regardless of format & algorithm)
 type PublicKey interface {

--- a/pkg/pki/ssh/ssh.go
+++ b/pkg/pki/ssh/ssh.go
@@ -167,7 +167,7 @@ func (k PublicKey) Identities() ([]identity.Identity, error) {
 			ecdsaPubKey.Curve = elliptic.P256()
 			//nolint:staticcheck // ignore SA1019 for old code
 			ecdsaPubKey.X, ecdsaPubKey.Y = elliptic.Unmarshal(ecdsaPubKey.Curve, w.KeyBytes)
-			if ecdsaPubKey.X == nil || ecdsaPubKey.Y == nil {
+			if ecdsaPubKey.X == nil || ecdsaPubKey.Y == nil { //nolint:staticcheck // ignore SA1019 for old code
 				return nil, errors.New("ssh: invalid curve point")
 			}
 			cryptoPubKey = ecdsaPubKey

--- a/pkg/pki/tuf/tuf.go
+++ b/pkg/pki/tuf/tuf.go
@@ -17,6 +17,7 @@ package tuf
 
 import (
 	"crypto/ed25519"
+	"crypto/fips140"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
@@ -126,6 +127,12 @@ func NewPublicKey(r io.Reader) (*PublicKey, error) {
 	// Now create a verification db that trusts all the keys
 	db := verify.NewDB()
 	for id, k := range root.Keys {
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		if fips140.Enabled() && k.Type == data.KeyTypeEd25519 {
+			return nil, errors.New("ed25519 is not supported in FIPS mode")
+		}
+		// ========================================
 		if err := db.AddKey(id, k); err != nil {
 			return nil, err
 		}

--- a/pkg/pki/x509/x509.go
+++ b/pkg/pki/x509/x509.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/asaskevich/govalidator"
 	"github.com/sigstore/rekor/pkg/pki/identity"
+	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	sigsig "github.com/sigstore/sigstore/pkg/signature"
 )
@@ -129,6 +130,14 @@ func NewPublicKey(r io.Reader) (*PublicKey, error) {
 		if err != nil {
 			return nil, err
 		}
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		for _, c := range certs {
+			if err := pkitypes.ValidatePublicKey(c.PublicKey); err != nil {
+				return nil, err
+			}
+		}
+		// ========================================
 		return &PublicKey{certs: certs}, nil
 	}
 
@@ -138,12 +147,24 @@ func NewPublicKey(r io.Reader) (*PublicKey, error) {
 		if err != nil {
 			return nil, err
 		}
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		if err := pkitypes.ValidatePublicKey(key); err != nil {
+			return nil, err
+		}
+		// ========================================
 		return &PublicKey{key: key}, nil
 	case string(cryptoutils.CertificatePEMType):
 		c, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
 			return nil, err
 		}
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		if err := pkitypes.ValidatePublicKey(c.PublicKey); err != nil {
+			return nil, err
+		}
+		// ========================================
 		return &PublicKey{
 			cert: &cert{
 				c: c,

--- a/pkg/types/alpine/alpine.go
+++ b/pkg/types/alpine/alpine.go
@@ -17,6 +17,7 @@ package alpine
 
 import (
 	"context"
+	"crypto/fips140"
 	"errors"
 	"fmt"
 
@@ -33,6 +34,12 @@ type BaseAlpineType struct {
 }
 
 func init() {
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if fips140.Enabled() {
+		return
+	}
+	// ========================================
 	types.TypeMap.Store(KIND, New)
 }
 

--- a/pkg/types/alpine/v0.0.1/entry.go
+++ b/pkg/types/alpine/v0.0.1/entry.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"crypto/fips140"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -47,6 +48,12 @@ const (
 )
 
 func init() {
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if fips140.Enabled() {
+		return
+	}
+	// ========================================
 	if err := alpine.VersionMap.SetEntryFactory(APIVERSION, NewEntry); err != nil {
 		log.Logger.Panic(err)
 	}

--- a/pkg/types/helm/helm.go
+++ b/pkg/types/helm/helm.go
@@ -17,6 +17,7 @@ package helm
 
 import (
 	"context"
+	"crypto/fips140"
 	"errors"
 	"fmt"
 
@@ -33,6 +34,12 @@ type BaseHelmType struct {
 }
 
 func init() {
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if fips140.Enabled() {
+		return
+	}
+	// ========================================
 	types.TypeMap.Store(KIND, New)
 }
 

--- a/pkg/types/helm/v0.0.1/entry.go
+++ b/pkg/types/helm/v0.0.1/entry.go
@@ -18,6 +18,7 @@ package helm
 import (
 	"bytes"
 	"context"
+	"crypto/fips140"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -45,6 +46,12 @@ const (
 )
 
 func init() {
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if fips140.Enabled() {
+		return
+	}
+	// ========================================
 	if err := helm.VersionMap.SetEntryFactory(APIVERSION, NewEntry); err != nil {
 		log.Logger.Panic(err)
 	}

--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"crypto/fips140"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -360,12 +361,32 @@ func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types
 	re.RekordObj.Signature = &models.RekordV001SchemaSignature{}
 	switch props.PKIFormat {
 	case "pgp":
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		// PGP uses golang.org/x/crypto/openpgp which is not FIPS-validated.
+		if fips140.Enabled() {
+			return nil, errors.New("pgp is not supported in FIPS mode")
+		}
+		// ========================================
 		re.RekordObj.Signature.Format = conv.Pointer(models.RekordV001SchemaSignatureFormatPgp)
 	case "minisign":
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		if fips140.Enabled() {
+			return nil, errors.New("minisign is not supported in FIPS mode")
+		}
+		// ========================================
 		re.RekordObj.Signature.Format = conv.Pointer(models.RekordV001SchemaSignatureFormatMinisign)
 	case "x509":
 		re.RekordObj.Signature.Format = conv.Pointer(models.RekordV001SchemaSignatureFormatX509)
 	case "ssh":
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		// SSH uses golang.org/x/crypto/ssh which is not FIPS-validated.
+		if fips140.Enabled() {
+			return nil, errors.New("ssh is not supported in FIPS mode")
+		}
+		// ========================================
 		re.RekordObj.Signature.Format = conv.Pointer(models.RekordV001SchemaSignatureFormatSSH)
 	default:
 		return nil, fmt.Errorf("unexpected format of public key: %s", props.PKIFormat)
@@ -422,18 +443,31 @@ func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 
 	var key pki.PublicKey
 	var err error
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	// PGP, SSH, and Minisign use non-FIPS-validated crypto modules.
 	switch f := *v.RekordObj.Signature.Format; f {
 	case "x509":
 		key, err = x509.NewPublicKey(bytes.NewReader(*v.RekordObj.Signature.PublicKey.Content))
 	case "ssh":
+		if fips140.Enabled() {
+			return nil, errors.New("ssh is not supported in FIPS mode")
+		}
 		key, err = ssh.NewPublicKey(bytes.NewReader(*v.RekordObj.Signature.PublicKey.Content))
 	case "pgp":
+		if fips140.Enabled() {
+			return nil, errors.New("pgp is not supported in FIPS mode")
+		}
 		key, err = pgp.NewPublicKey(bytes.NewReader(*v.RekordObj.Signature.PublicKey.Content))
 	case "minisign":
+		if fips140.Enabled() {
+			return nil, errors.New("minisign is not supported in FIPS mode")
+		}
 		key, err = minisign.NewPublicKey(bytes.NewReader(*v.RekordObj.Signature.PublicKey.Content))
 	default:
 		return nil, fmt.Errorf("unexpected format of public key: %s", f)
 	}
+	// ========================================
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/types/rpm/rpm.go
+++ b/pkg/types/rpm/rpm.go
@@ -17,6 +17,7 @@ package rpm
 
 import (
 	"context"
+	"crypto/fips140"
 	"errors"
 	"fmt"
 
@@ -33,6 +34,12 @@ type BaseRPMType struct {
 }
 
 func init() {
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if fips140.Enabled() {
+		return
+	}
+	// ========================================
 	types.TypeMap.Store(KIND, New)
 }
 

--- a/pkg/types/rpm/v0.0.1/entry.go
+++ b/pkg/types/rpm/v0.0.1/entry.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"crypto/fips140"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -49,6 +50,12 @@ const (
 )
 
 func init() {
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if fips140.Enabled() {
+		return
+	}
+	// ========================================
 	if err := rpm.VersionMap.SetEntryFactory(APIVERSION, NewEntry); err != nil {
 		log.Logger.Panic(err)
 	}

--- a/pkg/util/signed_note.go
+++ b/pkg/util/signed_note.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"strings"
 
+	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 	"golang.org/x/mod/sumdb/note"
@@ -54,6 +55,14 @@ func (s *SignedNote) Sign(identity string, signer signature.Signer, opts signatu
 	if err != nil {
 		return nil, fmt.Errorf("retrieving public key: %w", err)
 	}
+
+	// RHTAS FIPS - DO NOT REMOVE
+	// ========================================
+	if err := pkitypes.ValidatePublicKey(pk); err != nil {
+		return nil, err
+	}
+	// ========================================
+
 	pkHash, err := getPublicKeyHash(pk)
 	if err != nil {
 		return nil, err
@@ -99,6 +108,12 @@ func (s SignedNote) Verify(verifier signature.Verifier) bool {
 		}
 
 		opts := []signature.VerifyOption{}
+		// RHTAS FIPS - DO NOT REMOVE
+		// ========================================
+		if err := pkitypes.ValidatePublicKey(pk); err != nil {
+			return false
+		}
+		// ========================================
 		switch pk.(type) {
 		case *rsa.PublicKey, *ecdsa.PublicKey:
 			opts = append(opts, options.WithDigest(digest[:]))


### PR DESCRIPTION
## Summary
- Enable Go native FIPS 140 mode via `GOFIPS140=v1.0.0` and `fips140=auto` GODEBUG
- Disable PGP, SSH, and Minisign PKI modules in FIPS mode (`golang.org/x/crypto` is not FIPS-validated)
- Disable Alpine, Helm, and RPM entry types in FIPS mode (depend on PGP)
- Add centralized `ValidatePublicKey()` helper that rejects Ed25519, RSA < 2048-bit, and unsupported key types
- Guard x509, PKCS7, TUF key construction, checkpoint signing/verification, and CLI key loading
- Filter Ed25519 from allowed signing algorithms in server config
- No behavioral changes when FIPS is not enabled
