### PR TITLE
Update release-version to 1.3.6

### DIFF
--- a/.tekton/backfill-redis-pull-request.yaml
+++ b/.tekton/backfill-redis-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.5"
+    value: "1.3.6"
   - name: dockerfile
     value: Dockerfile.backfill-redis.rh
   - name: git-url

--- a/.tekton/backfill-redis-push.yaml
+++ b/.tekton/backfill-redis-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.5"
+    value: "1.3.6"
   - name: dockerfile
     value: Dockerfile.backfill-redis.rh
   - name: git-url

--- a/.tekton/rekor-cli-pull-request.yaml
+++ b/.tekton/rekor-cli-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.5"
+    value: "1.3.6"
   - name: dockerfile
     value: Dockerfile.rekor-cli.rh
   - name: git-url

--- a/.tekton/rekor-cli-push.yaml
+++ b/.tekton/rekor-cli-push.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.5"
+    value: "1.3.6"
   - name: dockerfile
     value: Dockerfile.rekor-cli.rh
   - name: git-url

--- a/.tekton/rekor-server-pull-request.yaml
+++ b/.tekton/rekor-server-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.5"
+    value: "1.3.6"
   - name: dockerfile
     value: Dockerfile.rekor-server.rh
   - name: git-url

--- a/.tekton/rekor-server-push.yaml
+++ b/.tekton/rekor-server-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.5"
+    value: "1.3.6"
   - name: dockerfile
     value: Dockerfile.rekor-server.rh
   - name: git-url


### PR DESCRIPTION
## Summary
Update the release-version parameter in Tekton pipeline definitions to 1.3.6 for the release-1.3 branch.

## Changes
- Updated release-version parameter from previous version to 1.3.6 in .tekton/ pipeline files

## Testing
- Verify pipeline parameter is correctly set
- Ensure pipelines can be triggered with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)