### PR TITLE
fix: FIPS 140-3 compliance updates for Go 1.26 native crypto module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,12 +53,6 @@ jobs:
           check-latest: true
           cache: false
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
-
       - name: deps
         run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,12 +58,6 @@ jobs:
         check-latest: true
         cache: false
 
-    - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-      run: |
-        go mod edit -dropgodebug=fips140
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        git update-index --assume-unchanged go.mod
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,12 +43,6 @@ jobs:
           go-version: ${{ env.GOVERSION }}
           cache: false
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
-
       - name: Build
         run: make -C $GITHUB_WORKSPACE all
       - name: Fuzz-Build
@@ -75,12 +69,6 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
           cache: false
-
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
 
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
@@ -112,12 +100,6 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
           cache: false
-
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
 
       - name: install gocovmerge
         run: make gocovmerge
@@ -172,12 +154,6 @@ jobs:
           go-version: ${{ env.GOVERSION }}
           cache: false
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
-
       - name: Install backfill test dependencies
         run: |
           go install ./cmd/rekor-cli
@@ -228,12 +204,6 @@ jobs:
           go-version: ${{ env.GOVERSION }}
           cache: false
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
-
       - name: Sharding Test
         run: ./tests/sharding-e2e-test.sh
       - name: Upload logs if they exist
@@ -252,12 +222,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
 
       - name: Docker Build
         run: docker compose build
@@ -286,12 +250,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
 
       - name: Docker Build
         run: docker compose build
@@ -339,15 +297,6 @@ jobs:
           go-version: ${{ env.GOVERSION }}
           check-latest: true
           cache: false
-
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git config user.email "ci@rhtas.dev"
-          git config user.name "CI"
-          git add go.mod
-          git commit -m "temp: drop fips140 godebug for CI"
 
       - name: Run test harness
         run: ./tests/rekor-harness.sh

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -94,12 +94,6 @@ jobs:
       - name: check disk space
         run: df -h
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
-
       - name: goreleaser snapshot
         run: make snapshot
         env:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -40,12 +40,6 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
 
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
-
       - name: Install addlicense
         run: go install github.com/google/addlicense@v1.0.0
 
@@ -69,12 +63,6 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GOVERSION }}
-
-      - name: Remove RHTAS FIPS godebug for upstream Go # RHTAS FIPS - DO NOT REMOVE
-        run: |
-          go mod edit -dropgodebug=fips140
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git update-index --assume-unchanged go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/.tekton/rekor-cli-pull-request.yaml
+++ b/.tekton/rekor-cli-pull-request.yaml
@@ -25,6 +25,8 @@ spec:
     value: "1.4.0"
   - name: dockerfile
     value: Dockerfile.rekor-cli.rh
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after

--- a/.tekton/rekor-cli-push.yaml
+++ b/.tekton/rekor-cli-push.yaml
@@ -25,6 +25,8 @@ spec:
     value: "1.4.0"
   - name: dockerfile
     value: Dockerfile.rekor-cli.rh
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image

--- a/.tekton/rekor-cli-stack-pull-request.yaml
+++ b/.tekton/rekor-cli-stack-pull-request.yaml
@@ -20,6 +20,8 @@ spec:
   params:
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after

--- a/.tekton/rekor-cli-stack-push.yaml
+++ b/.tekton/rekor-cli-stack-push.yaml
@@ -19,6 +19,8 @@ spec:
   params:
   - name: dockerfile
     value: Dockerfile.cli-stack.rh
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    value: "true"
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image

--- a/Build.mak
+++ b/Build.mak
@@ -28,8 +28,8 @@ SERVER_LDFLAGS=$(REKOR_LDFLAGS)
 FIPS_MODULE ?= v1.0.0
 
 .PHONY: rekor-cli-linux
-rekor-cli-linux: ## Build native Linux binary (FIPS, CGO)
-	env CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOFLAGS="-buildvcs=false" go build -o rekor_cli_linux -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
+rekor-cli-linux: ## Build native Linux binary (FIPS)
+	env CGO_ENABLED=0 GOFIPS140=$(FIPS_MODULE) GOFLAGS="-buildvcs=false -tags=no_openssl" go build -o rekor_cli_linux -trimpath -ldflags "$(CLI_LDFLAGS) -w -s" ./cmd/rekor-cli
 
 .PHONY:
 cross-platform: rekor-cli-darwin-arm64 rekor-cli-darwin-amd64 rekor-cli-windows ## Build all distributable (cross-platform) binaries

--- a/Dockerfile.backfill-redis.rh
+++ b/Dockerfile.backfill-redis.rh
@@ -11,6 +11,7 @@ RUN mkdir -p /opt/app-root && mkdir -p /opt/app-root/src && git config --global 
 
 WORKDIR /opt/app-root/src/
 COPY . .
+RUN go mod edit -godebug=fips140=auto
 
 RUN go mod download
 

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -21,10 +21,10 @@ RUN git update-index --assume-unchanged Dockerfile.rekor-cli.rh && \
     make Makefile.swagger && \
     make -f Build.mak cross-platform
 
-FROM --platform=linux/amd64   quay.io/securesign/rekor-cli@sha256:98bdae30cd639957f2dc143e2888fcdfaf406ea2a325db8de7d8b3692c8ed9f6 AS build-amd64
-FROM --platform=linux/arm64   quay.io/securesign/rekor-cli@sha256:98bdae30cd639957f2dc143e2888fcdfaf406ea2a325db8de7d8b3692c8ed9f6 AS build-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/rekor-cli@sha256:98bdae30cd639957f2dc143e2888fcdfaf406ea2a325db8de7d8b3692c8ed9f6 AS build-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/rekor-cli@sha256:98bdae30cd639957f2dc143e2888fcdfaf406ea2a325db8de7d8b3692c8ed9f6 AS build-s390x
+FROM --platform=linux/amd64   quay.io/securesign/rekor-cli@sha256:4f297ebc1917d68bd93903687b5ff0c0740801594a8ed234d676512f367e02a7 AS build-amd64
+FROM --platform=linux/arm64   quay.io/securesign/rekor-cli@sha256:73a707e13c90cc5388f2d0cf04cf4e650e951b62d1f7f5d688ac33fbc7f5cf6e AS build-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/rekor-cli@sha256:8bf706967755e6489dcc8e4e71717eef4452950c8b5184bc06336c8cc67812bf AS build-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/rekor-cli@sha256:44b2ded738016fae222db9319eb843612a2d67011b103ea82b9ef6b3e57ca198 AS build-s390x
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS packager
 USER root

--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -10,6 +10,7 @@ RUN mkdir -p /opt/app-root && mkdir -p /opt/app-root/src && git config --global 
 WORKDIR $APP_ROOT/src
 
 COPY . .
+RUN go mod edit -godebug=fips140=auto
 
 WORKDIR $APP_ROOT/src/hack/tools
 RUN go mod vendor

--- a/Dockerfile.rekor-cli.rh
+++ b/Dockerfile.rekor-cli.rh
@@ -13,6 +13,7 @@ RUN mkdir -p /opt/app-root && mkdir -p /opt/app-root/src && git config --global 
 WORKDIR /opt/app-root/src
 
 COPY . .
+RUN go mod edit -godebug=fips140=auto
 
 WORKDIR /opt/app-root/src/hack/tools
 RUN go mod vendor

--- a/Dockerfile.rekor-server.rh
+++ b/Dockerfile.rekor-server.rh
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8@sha256:355b23fe885cf565c9313a7e98db742df0aec21456244e808942c56489594251 AS build-env
+USER root
 
 RUN mkdir -p /opt/app-root && mkdir -p /opt/app-root/src && mkdir -p /opt/app-root/src/cmd && mkdir -p /opt/app-root/src/pkg && git config --global --add safe.directory /opt/app-root/src
 
@@ -25,6 +26,7 @@ ENV GOFIPS140=v1.0.0
 
 WORKDIR $APP_ROOT/src/
 ADD go.mod go.sum $APP_ROOT/src/
+RUN go mod edit -godebug=fips140=auto
 RUN go mod download
 
 # Add source code

--- a/cmd/rekor-cli/app/pflags.go
+++ b/cmd/rekor-cli/app/pflags.go
@@ -16,6 +16,7 @@
 package app
 
 import (
+	"crypto/fips140"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -105,7 +106,15 @@ func initializePFlagMap() {
 				}
 				return nil
 			}
-			return valueFactory(pkiFormatFlag, pkiFormatValidator, "pgp")
+			// RHTAS FIPS - DO NOT REMOVE
+			// ========================================
+			// PGP uses non-FIPS-validated crypto modules.
+			defaultPkiFormat := "pgp"
+			if fips140.Enabled() {
+				defaultPkiFormat = "x509"
+			}
+			return valueFactory(pkiFormatFlag, pkiFormatValidator, defaultPkiFormat)
+			// ========================================
 		},
 		typeFlag: func() pflag.Value {
 			// this ensures the type of the log entry matches a type supported in the CLI

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/sigstore/rekor
 
 go 1.26.3
 
-godebug fips140=auto
-
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/blang/semver v3.5.1+incompatible

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -69,24 +69,6 @@ var AllowedClientSigningAlgorithms = []v1.PublicKeyDetails{
 }
 var DefaultClientSigningAlgorithms = AllowedClientSigningAlgorithms
 
-// RHTAS FIPS - DO NOT REMOVE
-// ========================================
-func init() {
-	if fips140.Enabled() {
-		filtered := make([]v1.PublicKeyDetails, 0, len(AllowedClientSigningAlgorithms))
-		for _, a := range AllowedClientSigningAlgorithms {
-			if a == v1.PublicKeyDetails_PKIX_ED25519 || a == v1.PublicKeyDetails_PKIX_ED25519_PH {
-				continue
-			}
-			filtered = append(filtered, a)
-		}
-		AllowedClientSigningAlgorithms = filtered
-		DefaultClientSigningAlgorithms = AllowedClientSigningAlgorithms
-	}
-}
-
-// ========================================
-
 func NewAPI(treeID int64) (*API, error) {
 	ctx := context.Background()
 

--- a/pkg/pki/factory.go
+++ b/pkg/pki/factory.go
@@ -88,7 +88,7 @@ func init() {
 	// RHTAS FIPS - DO NOT REMOVE
 	// ========================================
 	// PGP (golang.org/x/crypto/openpgp), SSH (golang.org/x/crypto/ssh), and
-	// Minisign (ed25519-only) use non-FIPS-validated crypto modules.
+	// Minisign (golang.org/x/crypto/blake2b) use non-FIPS-validated crypto modules.
 	if !fips140.Enabled() {
 		artifactFactoryMap[PGP] = pkiImpl{
 			newPubKey: func(r io.Reader) (PublicKey, error) {

--- a/pkg/pki/pkitypes/types.go
+++ b/pkg/pki/pkitypes/types.go
@@ -21,7 +21,6 @@ import (
 	"crypto/ed25519"
 	"crypto/fips140"
 	"crypto/rsa"
-	"errors"
 	"fmt"
 	"io"
 
@@ -33,7 +32,7 @@ import (
 // ========================================
 // ValidatePublicKey checks whether a crypto.PublicKey uses a FIPS-approved
 // algorithm. Returns nil when FIPS mode is disabled or when the key is approved.
-// Approved: RSA (>= 2048-bit), ECDSA. Rejected: Ed25519, DSA, all others.
+// Approved: RSA (>= 2048-bit), ECDSA, Ed25519 (FIPS 186-5).
 func ValidatePublicKey(pub crypto.PublicKey) error {
 	if !fips140.Enabled() {
 		return nil
@@ -47,7 +46,7 @@ func ValidatePublicKey(pub crypto.PublicKey) error {
 	case *ecdsa.PublicKey:
 		return nil
 	case ed25519.PublicKey:
-		return errors.New("ed25519 is not supported in FIPS mode")
+		return nil
 	default:
 		return fmt.Errorf("unsupported key type %T in FIPS mode", pub)
 	}

--- a/pkg/pki/tuf/tuf.go
+++ b/pkg/pki/tuf/tuf.go
@@ -16,6 +16,7 @@
 package tuf
 
 import (
+	"crypto"
 	"crypto/ed25519"
 	"crypto/fips140"
 	"crypto/sha256"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
 	"github.com/sigstore/rekor/pkg/pki/identity"
+	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	sigsig "github.com/sigstore/sigstore/pkg/signature"
 	"github.com/theupdateframework/go-tuf/data"
@@ -129,8 +131,26 @@ func NewPublicKey(r io.Reader) (*PublicKey, error) {
 	for id, k := range root.Keys {
 		// RHTAS FIPS - DO NOT REMOVE
 		// ========================================
-		if fips140.Enabled() && k.Type == data.KeyTypeEd25519 {
-			return nil, errors.New("ed25519 is not supported in FIPS mode")
+		if fips140.Enabled() {
+			verifier, err := keys.GetVerifier(k)
+			if err != nil {
+				return nil, err
+			}
+			var pub crypto.PublicKey
+			switch k.Type {
+			case data.KeyTypeRSASSA_PSS_SHA256, "ecdsa-sha2-nistp256", "ecdsa":
+				pub, err = x509.ParsePKIXPublicKey([]byte(verifier.Public()))
+				if err != nil {
+					return nil, err
+				}
+			case data.KeyTypeEd25519:
+				pub = ed25519.PublicKey(verifier.Public())
+			}
+			if pub != nil {
+				if err := pkitypes.ValidatePublicKey(pub); err != nil {
+					return nil, err
+				}
+			}
 		}
 		// ========================================
 		if err := db.AddKey(id, k); err != nil {


### PR DESCRIPTION
## Summary
- Update build tooling to use Go 1.26 native FIPS 140-3 module (`GOFIPS140=v1.0.0`) instead of legacy `golang-fips`/OpenSSL toolchain
- Allow Ed25519 keys (FIPS 186-5 approved, CAVP cert A6650)
- Add FIPS key validation for TUF root keys
- Move `godebug fips140=auto` from go.mod into Red Hat Dockerfiles so the repo builds cleanly with upstream Go
- Remove all `dropgodebug` CI workaround steps
- Default rekor-cli PKI format to x509 under FIPS mode
