### PR TITLE
Update cli-stacks image digests from Wave 1 builds 2026-07-30

### DIFF
--- a/Dockerfile.cli-stack.rh
+++ b/Dockerfile.cli-stack.rh
@@ -18,10 +18,10 @@ RUN git update-index --assume-unchanged Dockerfile.rekor-cli.rh && \
     make Makefile.swagger && \
     make -f Build.mak cross-platform
 
-FROM --platform=linux/amd64   quay.io/securesign/rekor-cli@sha256:6dfa2846f34c5ad56be397d50cb924725f9cbcf1b4f4d9c295ea8cc9882de36e AS build-amd64
-FROM --platform=linux/arm64   quay.io/securesign/rekor-cli@sha256:51b6988028711b1654862e5980aa17c25d8426ffa713e4d7aecdf70788be68da AS build-arm64
-FROM --platform=linux/ppc64le quay.io/securesign/rekor-cli@sha256:345e4a109f9f3060d5c4f2a4c608bcc8e419505f4f26366313ccf74a2b014ba8 AS build-ppc64le
-FROM --platform=linux/s390x   quay.io/securesign/rekor-cli@sha256:f3304f59d31ebf41e393489d2fb3f3f8f12d0452d9f6ea83db44a9cd2e80a391 AS build-s390x
+FROM --platform=linux/amd64   quay.io/securesign/rekor-cli@sha256:2d6400f3d9ee4db96e5f9d3bc2499500e35e0dc0399df5090a41ff9fde4ac729 AS build-amd64
+FROM --platform=linux/arm64   quay.io/securesign/rekor-cli@sha256:adf057ecf3b9220adfd0ac4aeca581652539f49604bb572581cfc2089fc75e0a AS build-arm64
+FROM --platform=linux/ppc64le quay.io/securesign/rekor-cli@sha256:2223653550b5b997b079ba5c454cc0ad1d979194f92555b9d2132dcd0e281608 AS build-ppc64le
+FROM --platform=linux/s390x   quay.io/securesign/rekor-cli@sha256:de3e98edbc00e2d565949afd3273e4e427a67ac43fb3a3960a05cdea88873216 AS build-s390x
 
 FROM registry.redhat.io/ubi9/go-toolset:9.8-1785360201@sha256:272a3dd990bba320c2e246119a0019d10d627d0104938d5db77ba5ab3ae3a51d AS packager
 USER root


### PR DESCRIPTION
## Summary
This PR updates cli-stacks image digests in `Dockerfile.cli-stack.rh` with the latest Wave 1 builds for release 1.4.3.

### Source snapshots
From `releases/1.4.3/snapshots.yaml` Wave 1 builds (2026-07-30).