### PR TITLE
build: enable hermetic builds for rekor cli-stack

### DIFF
--- a/.tekton/rekor-cli-stack-pull-request.yaml
+++ b/.tekton/rekor-cli-stack-pull-request.yaml
@@ -32,8 +32,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   - name: hermetic
-    value: "false"
+    value: "true"
   - name: build-source-image
     value: "true"
   pipelineRef:

--- a/.tekton/rekor-cli-stack-push.yaml
+++ b/.tekton/rekor-cli-stack-push.yaml
@@ -29,8 +29,10 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   - name: hermetic
-    value: "false"
+    value: "true"
   - name: build-source-image
     value: "true"
   pipelineRef:


### PR DESCRIPTION
## Summary
- Enable hermetic builds for the `rekor-cli-stack` component (both push and pull-request pipelines)
- Add `prefetch-input` with gomod cachi2 prefetch to both pipelines

## Test plan
- [ ] Verify the cli-stack PR build passes with hermetic enabled