### PR TITLE
Fix cli-stack hermetic build: prefetch hack/tools dependencies

### DIFF
--- a/.tekton/rekor-cli-stack-pull-request.yaml
+++ b/.tekton/rekor-cli-stack-pull-request.yaml
@@ -33,7 +33,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
+    value: '[{"type": "gomod", "path": "."}, {"type": "gomod", "path": "hack/tools"}]'
   - name: hermetic
     value: "true"
   - name: build-source-image

--- a/.tekton/rekor-cli-stack-push.yaml
+++ b/.tekton/rekor-cli-stack-push.yaml
@@ -30,7 +30,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: prefetch-input
-    value: '{"type": "gomod", "path": "."}'
+    value: '[{"type": "gomod", "path": "."}, {"type": "gomod", "path": "hack/tools"}]'
   - name: hermetic
     value: "true"
   - name: build-source-image


### PR DESCRIPTION
## Summary
- Add `hack/tools` module path to `prefetch-input` in both cli-stack Tekton files (PR and push)
- The cli-stack Dockerfile vendors `hack/tools` for swagger code generation (`go-swagger`, `gocovmerge`) before cross-compiling, but cachi2 was only prefetching the root module dependencies

### Root cause
```
go-swagger@v0.33.2: reading file:///cachi2/output/deps/gomod/pkg/mod/cache/download/... no such file or directory
```
Hermetic build failed because `hack/tools/go.mod` dependencies were not in the cachi2 cache.

## Test plan
- [ ] cli-stack PR build passes with hermetic mode
- [ ] cli-stack push build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)